### PR TITLE
fix #445

### DIFF
--- a/components/PAC/SectionCard.vue
+++ b/components/PAC/SectionCard.vue
@@ -197,9 +197,10 @@
                 </v-col>
               </v-row>
               <v-row v-if="section.children && section.children.length">
+                <!-- use path without '.md' extension as key because we don't wan't to re-render the section card when a file section becomes a directory -->
                 <v-col
                   v-for="child in section.children"
-                  :key="child.path"
+                  :key="child.path.replace('.md', '')"
                   cols="12"
                 >
                   <PACSectionCard

--- a/pages/trames/_githubRef.vue
+++ b/pages/trames/_githubRef.vue
@@ -344,17 +344,14 @@ export default {
       }).eq('id', this.project.id)
     },
     findSection (sections, path) {
-      const section = sections.find(s => path.startsWith(s.path))
+      const flatSections = this.getFlatSections(sections)
+      const section = flatSections.find(s => s.path === path)
 
       if (!section) {
         throw new Error('Section not found')
       }
 
-      if (section.path === path) {
-        return section
-      }
-
-      return this.findSection(section.children, path)
+      return section
     },
     async saveOrder (section, orderChange) {
       const sectionPath = section.path

--- a/server-middleware/modules/github/tree.js
+++ b/server-middleware/modules/github/tree.js
@@ -190,7 +190,7 @@ module.exports = {
       })
     }
 
-    return this.findTree(root, path.split('/')).children
+    return this.findTree(root, path.split('/')).children ?? []
   },
   async getHistories (ref, paths) {
     function hash (string) {


### PR DESCRIPTION
- update section record in supabase when the section becomes a directory (to keep the same order)
- update path selection in supabase when the section becomes a directory (to keep it selected if it was)
- use path without ".md" extension as vue key to not re-render SectionCard component and prevent side effects (events not triggered, because component was destroyed)