### PR TITLE
Désactive formulaire d'onboarding

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -131,13 +131,6 @@ export default {
         { label: 'Documentez les avancées', value: 'frp' }
       ]
     }
-  },
-  mounted () {
-    if (!this.$user.id) {
-      this.$tally('n9d42K', {
-        max: 2
-      })
-    }
   }
 }
 </script>


### PR DESCRIPTION
Il était déjà inopérant à cause d'un bug dans `plugins/tally.js` mais il est préférable de le désactiver totalement au cas où on corrige le bug de `plugins/tally.js`.

Vu avec @Octaviedebs qui m'a [confirmé le souhait de ne pas le réactiver.](https://docurba.slack.com/archives/C03MM1AD199/p1731597344358149?thread_ts=1731575961.213599&cid=C03MM1AD199)