### PR TITLE
Pipedrive - Suppression du champ "shared"

### DIFF
--- a/server-middleware/modules/pipedrive.js
+++ b/server-middleware/modules/pipedrive.js
@@ -66,9 +66,6 @@ const fieldsMap = {
       false: 'Non connecté.e'
     }
   },
-  shared: {
-    key: '9f1578c96655a81a330eb09912f0a9b5c1f40d8b'
-  },
   write_frise: {
     key: '7689c2ed07954a7dc99d84b4a537532af46238f3'
   },

--- a/server-middleware/pipedrive.js
+++ b/server-middleware/pipedrive.js
@@ -187,15 +187,11 @@ async function updateSharing (sharingRecord) {
     })
   }
 
-  const sharingUpdate = {
-    shared: sharingRecord.created_at
-  }
-
-  // This will update the related key on pipedrive.
-  // Each role should be mapped to a pipedrive key.
-  sharingUpdate[sharingRecord.role] = sharingRecord.created_at
-
-  const update = await pipedrive.updatePerson(person.id, sharingUpdate)
+  const update = await pipedrive.updatePerson(person.id, {
+    // This will update the related key on pipedrive.
+    // Each role should be mapped to a pipedrive key.
+    [sharingRecord.role]: sharingRecord.created_at
+  })
 
   return update
 }
@@ -208,6 +204,8 @@ app.get('/sharing', async (req, res) => {
   const update = await updateSharing(sharings[0])
 
   console.log(update)
+
+  res.status(200).send('OK')
 })
 
 // ROUTE used by supabase webhook on insert in projects_sharing


### PR DESCRIPTION
Il n'est pas utilisé et nous avons maintenant 3 champs plus granulaires avec `write_frise`, `read` et `write`.

ref https://github.com/MTES-MCT/Docurba/issues/1007