### PR TITLE
Route API toujours en timeout

### DIFF
--- a/server-middleware/slack.js
+++ b/server-middleware/slack.js
@@ -139,9 +139,11 @@ app.post('/notify/frp', (req, res) => {
   slack.notifyFrpEvent(req.body).then((res) => {
     // eslint-disable-next-line no-console
     console.log('Slack then: ', res.data)
+    res.status(200).send('OK')
   }).catch((err) => {
     // eslint-disable-next-line no-console
     console.log('Slack catch', err.response.data)
+    res.status(500).send(err.response.data)
   })
 })
 


### PR DESCRIPTION
Dans les les logs applicatifs, nous voyons que /notify/frp est toujours en timeout car elle ne renvoie pas de statut et réponse