### PR TITLE
Procédure - Affichage 404 après la réponse de la BDD

### DIFF
--- a/pages/frise/_procedureId/index.vue
+++ b/pages/frise/_procedureId/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container v-if="!procedure">
+  <v-container v-if="loaded && !procedure">
     <h1 class="text-h1">
       Nous n'avons pas pu trouver cette procédure
     </h1>
@@ -381,6 +381,7 @@ export default
       if (errorProcedure) { throw errorProcedure }
 
       if (!procedure) {
+        this.loaded = true
         console.log('⚠️ 404')
         return
       }


### PR DESCRIPTION
En attendant la réponse de la base de données, nous affichions le message 404.

Bug introduit dans https://github.com/MTES-MCT/Docurba/pull/1020