### PR TITLE
Corrige nom de procédure pour EPCI sans fiscalité propre

### DIFF
--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -8,8 +8,15 @@ export default ({ app }, inject) => {
       const isInter = procedure?.procedures_perimetres?.length > 1
 
       let collectivitePorteuse = collectivite
-      if (isInter && collectivite?.intercommunaliteCode && collectivite?.groupements) {
-        collectivitePorteuse = collectivite.groupements.find(e => e.code === collectivite.intercommunaliteCode)
+      if (
+        isInter &&
+        collectivite &&
+        procedure.collectivite_porteuse_id !== collectivitePorteuse?.code
+      ) {
+        collectivitePorteuse = [
+          ...collectivite.groupements,
+          ...collectivite.membres
+        ].find(e => e.code === procedure.collectivite_porteuse_id)
       }
 
       const parts = [


### PR DESCRIPTION
Il faut aussi regarder parmi les membres pour trouver la collectivité porteuse

Pour rendre le test E2E "Mes collectivités" plus robuste, on vérifie toutes les titres de procédures en les cherchant par le lien vers la frise.

fix https://github.com/MTES-MCT/Docurba/issues/1117