### PR TITLE
Documentation de l'API

### DIFF
--- a/content/Dev/API/urba/communesCode.md
+++ b/content/Dev/API/urba/communesCode.md
@@ -1,12 +1,40 @@
 ---
-apiPath: "/api/urba/exports/departements/:code"
+apiPath: "/api/urba/exports/communes"
 files: []
 order: 10
 visible: true
 ---
-Renvoit les données d'urbanisme des communes d'un departement.
+## Route : `/api/urba/exports/communes`
 
-https://docurba.beta.gouv.fr/api/urba/exports/departements/01?csv=true
+### Description
+Cet endpoint retourne les données procédures par communes.
+
+---
+
+### Format de la requête
+
+#### Endpoint
+GET `/api/urba/exports/communes`
+
+#### Paramètres de requête disponibles :
+1. **`csv=true`**  
+   - Permet d'obtenir le résultat au format CSV au lieu de JSON.
+
+2. **Filtres sur les attributs des communes**  
+   Vous pouvez filtrer les communes en ajoutant des paramètres de requête basés sur les attributs suivants :
+   - `code` : Le code INSEE de la commune.
+   - `siren` : Le code SIREN de la commune.
+   - `regionCode` : Le code de la région.
+   - `departementCode` : Le code du département.
+   - `intercomunaliteCode` : Le code de l'intercommunalité.
+   - `competencePLU` : La compétence de la commune en matière de PLU (Plan Local d'Urbanisme) true/false.
+
+---
+
+### Format de la réponse
+
+La réponse est une liste d'objets, chaque objet représentant les données d'une commune. Voici la structure de la réponse :
+
 ```json
 {
   "epci_reg": "Code de la région de l'intercommunalité", // String
@@ -16,7 +44,6 @@ https://docurba.beta.gouv.fr/api/urba/exports/departements/01?csv=true
   "epci_type": "Type d'intercommunalité", // String
   "epci_nom": "Nom de l'intercommunalité", // String
   "epci_siren": "SIREN de l'intercommunalité", // String
-  "code_insee": "Code INSEE de la commune", // String
   "com_nom": "Nom de la commune", // String
   "collectivite_porteuse": "Code INSEE ou SIREN de la commune ou de l'intercommunalité porteuse", // String
   "plan_etat_code1": "Code état 1 sudocuh", // String
@@ -25,7 +52,7 @@ https://docurba.beta.gouv.fr/api/urba/exports/departements/01?csv=true
   "plan_libelle_etat_code2": "Libellé du code état 2 sudocuh", // String
   "plan_code_etat_bcsi": "Code état BCSI", // String
   "plan_libelle_code_etat_bcsi": "Libellé du code état BCSI", // String
-  "types_pc": "Type des procédures principales en cours", // String
+  "types_pc": "Types de procédures principales en cours", // String
   "pc_num_procedure": "Identifiant sudocuh de la procédure principale en cours", // Number
   "pc_nb_communes": "Nombre de communes dans le périmètre de la procédure en cours", // Number
   "pc_type_document": "Type de document du plan en cours", // String
@@ -49,11 +76,7 @@ https://docurba.beta.gouv.fr/api/urba/exports/departements/01?csv=true
   "pa_date_arret_projet": "Date ISO de l'arrêt de projet opposable", // String
   "pa_date_pac": "Date ISO du PAC opposable", // String
   "pa_date_pac_comp": "Date ISO de la complétion du PAC opposable", // String
-  "pa_date_approbation": "Date ISO de l'approbation du plan opposable", // String
-  "pa_annee_prescription": "Année de la prescription opposable", // Number
-  "pa_annee_approbation": "Année de l'approbation du plan opposable", // Number
-  "pa_date_executoire": "Date ISO de l'exécution du plan opposable", // String
-  "pa_delai_approbation": "Délai d'approbation du plan opposable", // Number
+  "pa_date_approval": "Date ISO de l'approbation du plan opposable", // String
   "pa_plui_valant_scot": "Le plan opposable vaut SCOT", // Boolean
   "pa_pluih": "Le plan opposable est un PLUIH", // Boolean
   "pa_pdu_tient_lieu": "Le plan opposable tient lieu de PDU", // Boolean
@@ -62,4 +85,3 @@ https://docurba.beta.gouv.fr/api/urba/exports/departements/01?csv=true
   "proc_nb_modifications": "Nombre de modifications", // Number
 }
 
-```

--- a/content/Dev/API/urba/perimetres.md
+++ b/content/Dev/API/urba/perimetres.md
@@ -1,0 +1,50 @@
+---
+apiPath: "/api/urba/exports/perimetres"
+files: []
+order: 10
+visible: true
+---
+## Documentation de l'API : `/api/urba/exports/perimetres`
+
+### Description
+Cet endpoint retourne code INSEE des communes par procédures.
+
+---
+
+### Format de la requête
+
+#### Endpoint
+`/api/urba/exports/perimetres`
+
+#### Paramètres de requête disponibles :
+1. **Filtres sur les attributs**  
+   Vous pouvez filtrer les résultats en utilisant les paramètres suivants :
+   - `collectivite_code` : Filtrer par le code de la collectivité. Utile pour retrouver l'historique des procédures d'une commune.
+   - `collectivite_type` : Filtrer par le type de collectivité. `collectivite_type=COM` permet d'exclure les COMD.
+   - `procedure_id` : Filtrer par l'identifiant de la procédure.
+   - `opposable` : Filtrer selon si le périmètre est opposable (`true` ou `false`).
+   - `departement` : Filtrer par le département.
+
+2. **`doc_type`**  
+   - Permet de filtrer le périmètre par type de procédure :
+     - `CC`
+     - `PLU`
+     - `SCOT`
+
+---
+
+### Format de la réponse
+
+La réponse est une liste d'objets, chaque objet représentant un périmètre avec les attributs suivants :
+
+```json
+{
+  "id": "Identifiant unique du périmètre", // String
+  "created_at": "Date de création du périmètre (ISO)", // String
+  "added_at": "Date d'ajout du périmètre (ISO)", // String
+  "collectivite_code": "Code INSEE de la collectivité associée", // String
+  "collectivite_type": "Type de la collectivité associée", // String
+  "procedure_id": "Identifiant de la procédure liée", // String
+  "opposable": "Indique si le périmètre est opposable", // Boolean
+  "departement": "Département du périmètre", // String
+}

--- a/content/Dev/API/urba/scots.md
+++ b/content/Dev/API/urba/scots.md
@@ -1,0 +1,64 @@
+---
+apiPath: "/api/urba/exports/scots"
+files: []
+order: 10
+visible: true
+---
+## Documentation de l'API : `/api/urba/exports/scots`
+
+### Description
+Cet endpoint retourne les données des procédures SCOTS par combinaison SCOT en cours/SCOT opposable. 
+
+⚠️ **Note importante :**  
+Une collectivité porteuse peut avoir plusieurs procédures opposables, et donc la même procédure en cours peut apparaître plusieurs fois.
+
+Ici la préposition `scot_` fait en faire référence à la collectivité porteuse des procédures de type SCOT de l'export.
+
+---
+
+### Format de la requête
+
+#### Endpoint
+`/api/urba/exports/scots`
+
+#### Paramètres de requête
+Aucun paramètre de requête disponible, car les fichiers générés sont plus petits.
+
+---
+
+### Format de la réponse
+
+La réponse est un objet JSON contenant les informations suivantes :
+
+```json
+{
+  "annee_cog": "Année de référence pour le COG (Code Officiel Géographique)", // Number
+  "scot_code_region": "Code de la région", // String
+  "scot_libelle_region": "Nom de la région", // String
+  "scot_code_departement": "Code du département", // String
+  "scot_lib_departement": "Nom du département", // String
+  "scot_codecollectivite": "SIREN de la collectivité porteuse", // String
+  "scot_code_type_collectivite": "Type de collectivité", // String
+  "scot_nom_collectivite": "Nom de la collectivité porteuse", // String
+  "pa_nom_schema": "Nom du document opposable", // String
+  "pa_id": "Identifiant du document opposable", // String
+  "pa_noserie_procedure": "Numéro de série de la procédure opposable (Sudocuh)", // String
+  "pa_scot_interdepartement": "Indique si le SCOT est interdépartemental", // Boolean
+  "pa_date_publication_perimetre": "Date de publication du périmètre de la procédure opposable (ISO)", // String
+  "pa_date_prescription": "Date de prescription de la procédure opposable (ISO)", // String
+  "pa_date_arret_projet": "Date d'arrêt de projet de la procédure opposable (ISO)", // String
+  "pa_date_approbation": "Date d'approbation de la procédure opposable (ISO)", // String
+  "pa_annee_approbation": "Année d'approbation de la procédure opposable", // Number
+  "pa_date_approbation_precedent": "Date d'approbation de la procédure opposable précédente (ISO)", // String
+  "pa_date_fin_echeance": "Date de fin d'échéance de la procédure opposable (ISO)", // String
+  "pa_nombre_communes": "Nombre de communes dans le périmètre de la procédure opposable", // Number
+  "pc_nom_schema": "Nom du document en cours", // String
+  "pc_id": "Identifiant du document en cours", // String
+  "pc_noserie_procedure": "Numéro de série de la procédure en cours (Sudocuh)", // String
+  "pc_proc_elaboration_revision": "Type de procédure en cours (élaboration, révision, etc.)", // String
+  "pc_scot_interdepartement": "Indique si le SCOT en cours est interdépartemental", // Boolean
+  "pc_date_publication_perimetre": "Date de publication du périmètre de la procédure en cours (ISO)", // String
+  "pc_date_prescription": "Date de prescription de la procédure en cours (ISO)", // String
+  "pc_date_arret_projet": "Date d'arrêt de projet de la procédure en cours (ISO)", // String
+  "pc_nombre_communes": "Nombre de communes dans le périmètre de la procédure en cours", // Number
+}


### PR DESCRIPTION
J'ai mis a jour la doc pour les exports communes, SCOT et perim. Elles sont disponible en public sur /dev/api --> https://docurba.beta.gouv.fr/dev/api