### PR TITLE
Création de procédure - Wording Périmètre

### DIFF
--- a/components/Ddt/PerimeterCheckInput.vue
+++ b/components/Ddt/PerimeterCheckInput.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col cols="12" class="pt-0">
-      <p> Communes concernées : ({{ perimetre.length }})</p>
+      <p> Périmètre du document d'urbanisme : ({{ perimetre.length }})</p>
       <v-btn
         color="primary"
         class="mr-4"


### PR DESCRIPTION
Pour les procédures secondaires, "communes concernées" pouvait laisser penser qu'il fallait n'en sélectionner qu'une quand il s'agit de rajouter ou enlever une commune au document d'urbanisme.