### PR TITLE
Fix liste des collaborateurs procédure secondaire Docurba

### DIFF
--- a/pages/frise/_procedureId/index.vue
+++ b/pages/frise/_procedureId/index.vue
@@ -412,19 +412,18 @@ export default
       }
       this.procedure = procedure
       console.log(' this.procedure: ', this.procedure)
+      this.procedure.project_id = this.procedure.project_id ?? this.procedure.secondary_procedure_of?.project_id
+
       const perimetre = this.procedure.procedures_perimetres.filter(c => c.collectivite_type === 'COM')
       const collectiviteId = perimetre.length === 1 ? perimetre[0].collectivite_code : this.procedure.collectivite_porteuse_id
-
       const { data: collectivite } = await axios({
         url: `/api/geo/collectivites/${collectiviteId}`
       })
-
       this.collectivite = collectivite
 
       this.events = await this.getEvents()
-      this.collaborators = await this.$sharing.getCollaborators(this.procedure, this.collectivite)
 
-      this.procedure.project_id = this.procedure.project_id ?? this.procedure.secondary_procedure_of?.project_id
+      this.collaborators = await this.$sharing.getCollaborators(this.procedure, this.collectivite)
       if (this.procedure.project_id) {
         const canShare = await this.$supabase.from('projects_sharing').select('id').eq('project_id', this.procedure.project_id).eq('user_email', this.$user.profile.email).eq('role', 'write_frise')
         this.canShare = canShare.data.length > 0


### PR DESCRIPTION
Pour trouver les partages dans `projects_sharing`, il faut avoir un `project_id`. Donc remontons cette ligne.

Cassé par https://github.com/MTES-MCT/Docurba/commit/04523ea1b8e06b651051d895b859ba470bc65ef4

ref https://github.com/MTES-MCT/Docurba/issues/1080