### PR TITLE
Page collectivité - Affichons les procédures sans collectivité connue

### DIFF
--- a/components/Dashboard/DUItem.vue
+++ b/components/Dashboard/DUItem.vue
@@ -1,5 +1,6 @@
 <template>
-  <div v-if="collectivite" class="mb-4">
+  <VGlobalLoader v-if="$fetchState.pending" />
+  <div v-else class="mb-4">
     <v-card outlined class="no-border-radius-bottom">
       <v-card-text>
         <DashboardDUProcedureItem
@@ -62,12 +63,8 @@ export default {
       collectivite: null
     }
   },
-  computed: {
-    isCommunal () {
-      return this.procedure.procedures_perimetres.length === 1
-    }
-  },
-  async mounted () {
+  fetchDelay: 0,
+  async fetch () {
     if (this.isCommunal) {
       this.collectivite = this.procedure.procedures_perimetres[0]
     } else {
@@ -77,6 +74,11 @@ export default {
       } catch (err) {
         console.log('no coll', this.procedure, this.collectivite)
       }
+    }
+  },
+  computed: {
+    isCommunal () {
+      return this.procedure.procedures_perimetres.length === 1
     }
   }
 }

--- a/tests_e2e/test_titre_procedure.py
+++ b/tests_e2e/test_titre_procedure.py
@@ -77,6 +77,9 @@ class CommonCollectivitePage:
         procedures_secondaires_buttons = self.page.get_by_role(
             "button", name="Procédures secondaires"
         )
+
+        expect(self.page.get_by_role("progressbar")).to_have_count(0)
+
         procedures_secondaires_buttons.first.wait_for()
         for button in procedures_secondaires_buttons.all():
             button.click()
@@ -87,6 +90,9 @@ class CommonCollectivitePage:
         procedures_secondaires_buttons = self.page.get_by_role(
             "button", name="Procédures secondaires"
         )
+
+        expect(self.page.get_by_role("progressbar")).to_have_count(0)
+
         procedures_secondaires_buttons.first.wait_for()
         for button in procedures_secondaires_buttons.all():
             button.click()
@@ -511,7 +517,9 @@ def test_ajout_procedure(page: Page, uuid, titre, code_departement, code_commune
         ),
     ],
 )
-def test_mes_collectivites_collectivite_porteuse_est_un_membre(page: Page, uuid, titre, code_departement):
+def test_mes_collectivites_collectivite_porteuse_est_un_membre(
+    page: Page, uuid, titre, code_departement
+):
     procedure_page = ProcedurePage.navigate(page, uuid)
     expect(procedure_page.titre).to_contain_text(titre)
 


### PR DESCRIPTION
https://github.com/MTES-MCT/Docurba/commit/d5b9f42da8edf4557bf6ad4913b53453ad71b4e3 a caché les procédures sans collectivité connue. L'intention était d'éviter des erreurs Vue tant que le fetch n'avait pas terminé. Plutôt que de tester que le fetch ait terminé, il vérifiait si `collectivite` avait une valeur.

On vérifie maintenant si le fetch est en attente.

ref https://github.com/MTES-MCT/Docurba/issues/792