### PR TITLE
Changed event list for POS to make them 'abandon' or 'caduc' instead …

### DIFF
--- a/daily_dump/steps/sql/status_handler/1-get_event_impact.sql
+++ b/daily_dump/steps/sql/status_handler/1-get_event_impact.sql
@@ -40,11 +40,11 @@ declare
         "caduc": ["Caducité"]
       },
       "POS": {
-        "en cours": ["Délibération de prescription du conseil municipal ou communautaire"],
-        "opposable": ["Caractère exécutoire", "Délibération d''approbation du municipal ou communautaire", "Délibération d''approbation du conseil municipal ou communautaire", "Délibération d''approbation"],
-        "abandon": ["Abandon"],
+        "en cours": [],
+        "opposable": [],
+        "abandon": ["Abandon", "Délibération de prescription du conseil municipal ou communautaire"],
         "annule": ["Annulation TA", "Annulation TA totale", "Caducité"],
-        "caduc": []
+        "caduc": ["Caractère exécutoire", "Délibération d''approbation du municipal ou communautaire", "Délibération d''approbation du conseil municipal ou communautaire", "Délibération d''approbation"]
       }
     }';
 begin


### PR DESCRIPTION
Ce que je propose est finalement un changement "léger". Puisqu'on veut que les e cour deviennent abandonées et les opposable caduc on peu faire ce changement dans la liste des events impactants dans le sql.

Je préfère cette solution parce que finalement si on fait le calcul en bout de chaine ça ne permet pas d'avoir une table de perimetre à jours. Les POS seront toujours considérer comme opposable dans la table perim alors que c'est false.

L'avantage: C'est systématique et ça permet d'avoir la table perim à jours.

L'inconvénient: Les POS précédents vont passé en CADUC. Ce n'est pas une information fausse. Mais ce n'est pas non plus une information parfaite. Par exempe, si il y a eu 2 POS sur une commune. Au moins un devrait avoir un status précédent et l'autre pourrait être précédent ou caduc. Ici les deux seront caduc ce qui ne représente pas le véritable historique.

Je pense que la véracité de la table perim est plus importante que la précision de l'historique des POS. Sinon il faudrait implémenté une logique suplémentaire sur la mise a jour de la table PERIM spécifiquement pour les POS.

@rik dit moi si tu veux que je fasse une proposition pour la solution sur la table PERIM.