### PR TITLE
Passer les suppressions en soft_delete

### DIFF
--- a/nuxt/components/Dashboard/DUProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUProcedureItem.vue
@@ -151,7 +151,7 @@ export default {
       try {
         const { error } = await this.$supabase
           .from('procedures')
-          .delete()
+          .update({ soft_delete: true })
           .eq('id', idProcedure)
 
         if (error) { throw error }

--- a/nuxt/components/Dashboard/DUSubProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUSubProcedureItem.vue
@@ -140,7 +140,7 @@ export default {
       try {
         const { error } = await this.$supabase
           .from('procedures')
-          .delete()
+          .update({ soft_delete: true })
           .eq('id', idProcedure)
 
         if (error) { throw error }

--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -484,7 +484,11 @@ export default
     },
     async archiveProcedure (idProcedure) {
       try {
-        const { error } = await this.$supabase.from('procedures').delete().eq('id', idProcedure)
+        const { error } = await this.$supabase
+          .from('procedures')
+          .update({ soft_delete: true })
+          .eq('id', idProcedure)
+
         if (error) { throw error }
         this.$emit('delete', idProcedure)
         this.dialog = false


### PR DESCRIPTION
J'étais initialement partis sur un plugin qui faisait 2 opperations. Une première qui passe la procédure en soft delete. Puis une deuxième qui update le perimetre en opposable false.

Ca marchait bien mais en testant je me suis demander ce qu'il se passe si une des operations fail. Dans ce cas on se retrouve avec une incohérence entre les deux table.

J'aurais pu faire un trigger. Mais de nouveau on aurai eu du delay et ça revient au même pour la gestion d'erreur.

Du coup j'ai fais une function sql qui fait les deux opérations. Mais comme c'est dans une transaction. Si une des deux fail les changements ne seront pas pris en compte.

```sql
CREATE OR REPLACE FUNCTION soft_delete_procedure(deleted_procedure_id uuid)
RETURNS void LANGUAGE sql AS $$
    -- Update procedures
    UPDATE procedures
    SET soft_delete = true
    WHERE id = deleted_procedure_id;

    -- Update procedures_perimetres
    UPDATE procedures_perimetres
    SET opposable = false
    WHERE procedure_id = deleted_procedure_id;
$$;
```
La procédure de test:
- Créer une procédure (je conseille sur une seule commune au RNU)
- La rendre opposable
- Vérifier le status et la table perimetre
- soft_delete la procédure
- Re vérifier le status et la table perimetre
- Delete la procédure en BDD

Comme on a plus de delete en cascade avec cette methode. Il faut faire attention à bien supprimer les test. Sinon on peu se retrouver avec beaucoup de procédures de test difficilement discernable des test utilisateurs ou des vrais soft_delete.