### PR TITLE
Remettre à plat les intitulés des rôles et postes

### DIFF
--- a/nuxt/components/Frise/ShareDialog.vue
+++ b/nuxt/components/Frise/ShareDialog.vue
@@ -46,15 +46,7 @@
                         {{ item.label }}
                       </v-list-item-title>
                       <v-list-item-subtitle>
-                        <span> {{ $utils.posteDetails(item.poste) }}</span>
-                        <template v-if="item.detailsPoste">
-                          <span
-                            v-for="detail in item.detailsPoste"
-                            :key="`colab-${item.email}-${detail}`"
-                          >
-                            {{ ', ' + $utils.posteDetails(detail) }}
-                          </span>
-                        </template>
+                        {{ $utils.formatPostes(item) }}
                       </v-list-item-subtitle>
                     </v-list-item-content>
                   </v-list-item>
@@ -97,10 +89,7 @@
                           {{ collaborator.label }}
                         </v-list-item-title>
                         <v-list-item-subtitle>
-                          <span> {{ $utils.posteDetails(collaborator.poste) }}</span>
-                          <template v-if="collaborator.detailsPoste">
-                            <span v-for="detail in collaborator.detailsPoste" :key="`colab-${collaborator.email}-${detail}`">{{ ', ' + $utils.posteDetails(detail) }}</span>
-                          </template>
+                          {{ $utils.formatPostes(collaborator) }}
                         </v-list-item-subtitle>
                       </v-list-item-content>
                       <v-list-item-action>

--- a/nuxt/components/Onboarding/SignupForm.vue
+++ b/nuxt/components/Onboarding/SignupForm.vue
@@ -23,7 +23,7 @@
         <v-select
           v-model="userData.poste"
           :error-messages="errors"
-          :items="roles"
+          :items="postes"
           filled
           label="Administration"
         />
@@ -35,7 +35,7 @@
           v-model="userData.other_poste"
           multiple
           :error-messages="errors"
-          :items="postes"
+          :items="roles"
           filled
           label="Rôle(s)"
         />
@@ -81,17 +81,12 @@ export default {
   },
   data () {
     return {
-      roles: [
-        { text: 'DDT/DEAL', value: 'ddt' },
-        { text: 'DREAL', value: 'dreal' }
-      ],
-      postes: [
-        { text: 'Chef d\'unité/de bureau/de service et adjoint', value: 'chef_unite' },
-        { text: 'Rédacteur(ice) de PAC ', value: 'redacteur_pac' },
-        { text: 'Chargé(e) de l\'accompagnement des collectivités', value: 'suivi_procedures' },
-        { text: 'Référent(e) Sudocuh', value: 'referent_sudocuh' }
-
-      ],
+      postes: Object.entries(this.$utils.POSTES_ETAT).map(
+        ([value, text]) => ({ value, text })
+      ),
+      roles: Object.entries(this.$utils.ROLES_ETAT).map(
+        ([value, text]) => ({ value, text })
+      ),
       icons: {
         mdiEye,
         mdiEyeOff

--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -164,27 +164,21 @@
                     Collaborateurs
                   </div>
                   <div class="mb-4">
-                    <v-list two-line dense class="py-0">
+                    <ul class="pl-0">
                       <template v-for="(collaborator, icollab) in toDisplayCollabs">
-                        <v-list-item v-if="icollab < 3 || showAllCollabs" :key="collaborator.id" class="pl-0">
-                          <v-list-item-avatar :color="collaborator.color" class="text-capitalize white--text font-weight-bold">
+                        <li v-if="icollab < 3 || showAllCollabs" :key="collaborator.id" class="d-flex py-2 text-body-2 font-weight-medium" style="font-size: .8125rem !important; gap: 0.5rem;">
+                          <v-avatar size="40" :color="collaborator.color" class="text-capitalize text-body-1 font-weight-bold white--text">
                             {{ collaborator.avatar }}
-                          </v-list-item-avatar>
-                          <v-list-item-content>
-                            <v-list-item-title>
-                              {{ collaborator.label }}
-                            </v-list-item-title>
-                            <v-list-item-subtitle>
-                              <span> {{ $utils.posteDetails(collaborator.poste) }}</span>
-
-                              <template v-if="collaborator.detailsPoste">
-                                <span v-for="detail in collaborator.detailsPoste" :key="`colab-${collaborator.email}-${detail}`">{{ ', ' + $utils.posteDetails(detail) }}</span>
-                              </template>
-                            </v-list-item-subtitle>
-                          </v-list-item-content>
-                        </v-list-item>
+                          </v-avatar>
+                          <div>
+                            {{ collaborator.label }}
+                            <div class="mention-grey--text">
+                              {{ $utils.formatPostes(collaborator) }}
+                            </div>
+                          </div>
+                        </li>
                       </template>
-                    </v-list>
+                    </ul>
                     <v-btn v-if="collaborators?.length > 3" class="mt-2" depressed @click="showAllCollabs = !showAllCollabs">
                       <span v-if="showAllCollabs">Cacher</span>
                       <span v-else>Voir plus</span>

--- a/nuxt/pages/frise/_procedureId/invite.vue
+++ b/nuxt/pages/frise/_procedureId/invite.vue
@@ -51,10 +51,7 @@
                                 {{ collaborator.label }}
                               </v-list-item-title>
                               <v-list-item-subtitle>
-                                <span> {{ $utils.posteDetails(collaborator.poste) }}</span>
-                                <template v-if="collaborator.detailsPoste">
-                                  <span v-for="detail in collaborator.detailsPoste" :key="`colab-${collaborator.email}-${detail}`">{{ ', ' + $utils.posteDetails(detail) }}</span>
-                                </template>
+                                {{ $utils.formatPostes(collaborator) }}
                               </v-list-item-subtitle>
                             </v-list-item-content>
                             <v-list-item-action>

--- a/nuxt/pages/login/collectivites/signup.vue
+++ b/nuxt/pages/login/collectivites/signup.vue
@@ -141,13 +141,9 @@ export default {
   data () {
     return {
       icons: { mdiArrowLeft },
-      postes: [
-        { text: 'Bureau d\'étude', value: 'be' },
-        { text: 'Elu(e)', value: 'elu' },
-        { text: 'Technicien(ne) ou employé(e)', value: 'employe_mairie' },
-        { text: 'Agence d\'urbanisme', value: 'agence_urba' },
-        { text: 'Autre', value: 'autre' }
-      ],
+      postes: Object.entries(this.$utils.POSTES_COLLECTIVITE).map(
+        ([value, text]) => ({ value, text })
+      ),
       selectedCollectivite: {},
       loading: false,
       userData: {

--- a/nuxt/plugins/utils.js
+++ b/nuxt/plugins/utils.js
@@ -53,19 +53,37 @@ export default ({ app }, inject) => {
       creator.initiator = !!profile.initiator
       return creator
     },
-    posteDetails (techName) {
-      const map = {
-        employe_mairie: 'Employé de mairie',
-        redacteur_pac: 'Rédacteur de PAC',
-        ddt: 'DDT',
-        be: 'Bureau d\'étude',
-        elu: 'Élu',
-        autre: 'Autre',
-        suivi_procedures: 'Suivi de procédure',
-        referent_sudocuh: 'Référent Sudocuh',
-        chef_unite: 'Chef d\'unité'
+    // ⚠️ Les clefs sont a minima aussi utilisées pour Pipedrive et Brevo
+    POSTES_ETAT: {
+      ddt: 'DDT(M)/DEAL',
+      dreal: 'DREAL'
+    },
+    ROLES_ETAT: {
+      chef_unite: 'Chef·fe d\'unité/de bureau/de service et adjoint·e',
+      redacteur_pac: 'Rédacteur·ice de PAC',
+      suivi_procedures: 'Chargé·e de l\'accompagnement des collectivités',
+      referent_sudocuh: 'Référent·e Sudocuh'
+    },
+    POSTES_COLLECTIVITE: {
+      be: 'Bureau d\'études',
+      elu: 'Collectivité, Élu·e',
+      employe_mairie: 'Collectivité, Technicien·ne ou employé·e',
+      agence_urba: 'Agence d\'urbanisme',
+      autre: 'Autre'
+    },
+    formatPostes (profile) {
+      const postes = []
+
+      const POSTES = { ...this.POSTES_ETAT, ...this.POSTES_COLLECTIVITE }
+      if (profile.poste !== 'autre') {
+        postes.push(POSTES[profile.poste])
       }
-      return map[techName] ?? techName
+
+      for (const poste of profile.detailsPoste ?? []) {
+        postes.push(this.ROLES_ETAT[poste] ?? poste)
+      }
+
+      return postes.join(', ')
     }
   }
   inject('utils', utils)


### PR DESCRIPTION
- Centralise la définition des postes et rôles dans un seul fichier
- Les rôles et postes sont identiques entre l'inscription et les affichages des collaborateurs.
- Sur la frise, les noms et intitulés ne sont plus tronqués
- "agence_urba" devient être "Agence d'urbanisme" [Exemple](https://docurba.beta.gouv.fr/frise/305024ef-0d8e-47ae-8251-77da6a9bd6a5)
- Enlève l'espace précédent la virgule entre le rôle et les postes "DDT , Suivi de procédure" 🤓
- Utilise le point médian
- Renomme "Employé de mairie" en "Technicien·ne ou employé·e"
- Enlève "Autre" [Exemple](https://docurba.beta.gouv.fr/frise/b0363148-3f86-4800-9bc2-890e05c891a3)
- Préfixe certains postes par "Collectivité, " [Exemple 1](https://docurba.beta.gouv.fr/frise/a52676e3-4368-4b07-b7e1-6425e0ce444a) [Exemple 2](https://docurba.beta.gouv.fr/frise/5a691595-b5e9-4e46-bb0d-40a517b7319b)