### PR TITLE
Event - Expliquer la visibilité

### DIFF
--- a/nuxt/components/Frise/EventCard.vue
+++ b/nuxt/components/Frise/EventCard.vue
@@ -38,7 +38,7 @@
                   Privé
                 </v-chip>
               </template>
-              Cet événement n’est visible que pour la collectivité et les services de l’État.
+              Visible uniquement par les collaborateur·ices de la procédure
             </v-tooltip>
             <v-btn v-if="creator.label != 'Sudocuh' && ($user.profile?.side === 'etat' || event.profile_id === $user.id )" class="ml-2" text icon :to="`/frise/${event.procedure_id}/${event.id}?typeDu=${typeDu}`">
               <v-icon color="grey darken-2">

--- a/nuxt/components/Frise/EventForm.vue
+++ b/nuxt/components/Frise/EventForm.vue
@@ -18,17 +18,17 @@
                     label="Description"
                     filled
                     hide-details=""
-                    placeholder="Vous pouvez inscrire ici une description qui sera visible par tous"
                   />
                 </v-col>
                 <v-col cols="12">
                   <v-select
                     v-model="event.visibility"
-                    persistent-hint
-                    hint="Les événements privés sont visibles uniquement par la DDT et la collectivité en charge de la procédure, ainsi que par le bureau d’études le cas échéant."
                     label="Visibilité de l'évènement"
                     filled
-                    :items="[{value: 'public', text: 'Publique'}, {value: 'private', text: 'Privé'}]"
+                    :items="[
+                      {value: 'public', text: 'Publique - Visible par le grand public'},
+                      {value: 'private', text: 'Privé - Visible uniquement par les collaborateur·ices de la procédure'},
+                    ]"
                   />
                 </v-col>
                 <v-col cols="12">


### PR DESCRIPTION
- Lors de l'ajout d'event, plutôt qu'un hint, chaque label explicite la visibilité.
- Sur la feuille de route, le tooltip Privé parle des collaborateur·ices de la procédure.

fix https://github.com/MTES-MCT/Docurba/issues/1264