### PR TITLE
DRY - Procedure.is_principale devient Procedure.parente

### DIFF
--- a/django/core/admin.py
+++ b/django/core/admin.py
@@ -13,7 +13,7 @@ class CommuneProcedureInline(admin.StackedInline):
 class ProcedureAdmin(admin.ModelAdmin):
     readonly_fields = ("id", "created_at")
     list_filter = (
-        "is_principale",
+        ("parente", admin.EmptyFieldListFilter),
         ("name", admin.EmptyFieldListFilter),
     )
     list_display = ("__str__", "statut")

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -188,7 +188,13 @@ class Procedure(models.Model):
     type_document = models.CharField(  # noqa: DJ001
         choices=TypeDocument, db_column="doc_type", blank=True, null=True
     )
-    is_principale = models.BooleanField(blank=True, null=True)
+    parente = models.ForeignKey(
+        "self",
+        models.CASCADE,
+        db_column="secondary_procedure_of",
+        related_name="secondaires",
+        null=True,
+    )
     name = models.TextField(blank=True, null=True)  # noqa: DJ001
     type = models.CharField(blank=True, null=True)  # noqa: DJ001
     numero = models.CharField(blank=True, null=True)  # noqa: DJ001
@@ -227,7 +233,7 @@ class Procedure(models.Model):
 
     @property
     def statut(self) -> EventImpact | None:
-        if not self.is_principale:
+        if self.parente_id:
             return None
         if not self.dernier_event_impactant:
             return None
@@ -280,7 +286,7 @@ class CommuneProcedureQuerySet(models.QuerySet):
     ) -> list["CommuneProcedure"]:
         communes_procedures = (
             self.filter(
-                procedure__is_principale=True,
+                procedure__parente=None,
                 procedure__archived=False,
             )
             .prefetch_related(

--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -9,7 +9,6 @@ from core.models import CommuneProcedure, Procedure, TypeDocument
 def create_commune_procedure(*, code: str, departement: str) -> CommuneProcedure:
     procedure = Procedure.objects.create(
         type_document=TypeDocument.PLU,
-        is_principale=True,
         collectivite_porteuse_id=code,
     )
     return procedure.perimetre.create(


### PR DESCRIPTION
La colonne `is_principale` est redondante avec l'absence de valeur dans la colonne `secondary_procedure_of`.