### PR TITLE
Mes Procédures - Affiche la date correcte pour les événements

### DIFF
--- a/nuxt/pages/ddt/_departement/procedures/index.vue
+++ b/nuxt/pages/ddt/_departement/procedures/index.vue
@@ -133,12 +133,12 @@
           <!-- eslint-disable-next-line -->
           <template #item.prescription="{ item }">
 
-            <span class="mention-grey--text">{{ item.prescription?.date_iso ? item.prescription?.date_iso : '-' }}</span>
+            <span class="mention-grey--text">{{ item.prescription?.date_iso_formattee ?? '-' }}</span>
           </template>
 
           <!-- eslint-disable-next-line -->
           <template #item.last_event="{ item }">
-            <span class="mention-grey--text">{{ item.last_event?.date_iso }} - {{ item.last_event?.type }}</span>
+            <span class="mention-grey--text">{{ item.last_event?.date_iso_formattee }} - {{ item.last_event?.type }}</span>
           </template>
         </v-data-table>
       </v-col>
@@ -210,10 +210,10 @@ export default {
         const procedureName = this.$utils.formatProcedureName({ ...e.procedures, procedures_perimetres: e.perimetre }, collectivitePorteuse)
 
         if (e.prescription?.date_iso) {
-          e.prescription.date_iso = dayjs(e.prescription.date_iso).format('DD/MM/YYYY')
+          e.prescription.date_iso_formattee = dayjs(e.prescription.date_iso).format('DD/MM/YYYY')
         }
         if (e.last_event?.date_iso) {
-          e.last_event.date_iso = dayjs(e.last_event.date_iso).format('DD/MM/YYYY')
+          e.last_event.date_iso_formattee = dayjs(e.last_event.date_iso).format('DD/MM/YYYY')
         }
 
         return { ...e, procedureName }


### PR DESCRIPTION
Pour une raison que je ne comprends pas, on pouvait avoir une date qui inversait le jour et le mois ou des "Invalid date". Peut-être un partage d'objets sous-jacent.

En stockant la date formatée dans une nouvelle propriété, on évite de modifier la date originale. Ce qui rend plusieurs formattages idempotents.

fix https://github.com/MTES-MCT/Docurba/issues/791
fix https://github.com/MTES-MCT/Docurba/issues/1270