### PR TITLE
API Périmètres - Ajoute colonne "annee_cog"

### DIFF
--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -38,6 +38,7 @@ class TestAPIPerimetres:
 
         assert list(reader) == [
             {
+                "annee_cog": "2024",
                 "collectivite_code": "12345",
                 "collectivite_type": "COM",
                 "procedure_id": str(commune.procedures.first().id),

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -35,6 +35,7 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
         response,
         dialect="unix",
         fieldnames=[
+            "annee_cog",
             "collectivite_code",
             "collectivite_type",
             "procedure_id",
@@ -45,6 +46,7 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
     csv_writer.writeheader()
     csv_writer.writerows(
         {
+            "annee_cog": "2024",
             "collectivite_code": commune.code_insee,
             "collectivite_type": commune.type,
             "procedure_id": procedure.id,


### PR DESCRIPTION
Pour l'instant, c'est hardcodé car on ne supporte qu'un seul Code Officiel Géographique.

ref https://github.com/MTES-MCT/Docurba/issues/1181