### PR TITLE
Permet de consulter les pages d'un gros groupement

### DIFF
--- a/django/Procfile
+++ b/django/Procfile
@@ -1,2 +1,4 @@
-web: gunicorn core.wsgi --worker-class=gevent --log-file=-
+web: gunicorn core.wsgi --worker-class=gevent --limit-request-line=0 --log-file=-
+# limit-request-line désactivé à cause de https://github.com/MTES-MCT/Docurba/issues/1237
+
 postdeploy: bin/post_deploy


### PR DESCRIPTION
Le site Nuxt génère des URLs pour récupérer les informations de toutes les communes appartenant à un groupement. Pour les plus gros groupements, cela génère des URLs dépassant 4094 octets, [valeur par défaut de limit-request-line dans Gunicorn](https://docs.gunicorn.org/en/latest/settings.html#limit-request-line).

En attendant de remplacer par Django, on désactive cette limite. Cela pourrait faciliter un DDOS mais comme c'était le comportement avant l'introduction de Django, ce n'est pas un nouveau risque.

Problème introduit par https://github.com/MTES-MCT/Docurba/commit/f7614e8c

ref https://github.com/MTES-MCT/Docurba/issues/1237