### PR TITLE
Collaborateurs FRP - Cache les comptes is_staff

### DIFF
--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -292,7 +292,7 @@ export default
   },
   computed: {
     toDisplayCollabs () {
-      return this.$sharing.excludeTestCollabs(this.collaborators)
+      return this.$sharing.excludeStaff(this.collaborators)
     },
     isEmptyFrise () {
       return this.events.length === 0 || this.events.every(e => !e.type || !e.date_iso)

--- a/nuxt/plugins/sharing.js
+++ b/nuxt/plugins/sharing.js
@@ -78,7 +78,7 @@ export default ({ app, $supabase, $utils, $user, $analytics }, inject) => {
       let collaborators = [...stateProfiles, ...collectiviteProfiles].map(e => $utils.formatProfileToCreator(e))
       if (errorCollaborators) { throw errorCollaborators }
 
-      collaborators = this.excludeTestCollabs(collaborators)
+      collaborators = this.excludeStaff(collaborators)
       return collaborators
     },
     async  getCollaborators (procedure, collectivite) {
@@ -125,21 +125,10 @@ export default ({ app, $supabase, $utils, $user, $analytics }, inject) => {
       const finalCollabs = [...noProfilesCollabs, ...formattedProfiles]
       const uniqFinalCollabs = _.uniqBy(finalCollabs, e => e.email)
       return uniqFinalCollabs
-      // const realCollabsOnly = this.excludeTestCollabs(uniqFinalCollabs)
-      // return realCollabsOnly
     },
-    excludeTestCollabs (collabs) {
+    excludeStaff (collabs) {
       return collabs.filter((collab) => {
-        const email = collab.email.toLowerCase()
-        return !email.includes('test') &&
-        !email.includes('docurba.beta.gouv') &&
-        !email.includes('yopmail') &&
-        !email.includes('okie09@hotmail.fr') &&
-        !email.includes('celia.vermicelli@gmail.com') &&
-        // !email.includes('julien@quantedsquare.com') &&
-        !email.includes('fabien@quantedsquare.com') &&
-        !email.includes('julien.zmiro@gmail.com') &&
-        !email.includes(' vermicellicelia@gmail.com')
+        return !(collab.profile?.is_admin || collab.profile?.is_staff)
       })
     }
   }

--- a/nuxt/plugins/utils.js
+++ b/nuxt/plugins/utils.js
@@ -51,6 +51,7 @@ export default ({ app }, inject) => {
       creator.legacy_sudocu = profile.legacy_sudocu ?? false
       creator.id = profile.user_id
       creator.initiator = !!profile.initiator
+      creator.profile = profile
       return creator
     },
     // ⚠️ Les clefs sont a minima aussi utilisées pour Pipedrive et Brevo


### PR DESCRIPTION
Plutôt que de s'appuyer sur une liste statique et avec des règles arbitraires, utilisons une colonne dans la base de données.

Cela permet aussi d'afficher les collaborateurs de collectivités comme Hautes Terres ou La Teste De Buch (qui ont des emails contenant "test")

fix https://github.com/MTES-MCT/Docurba/issues/877