### PR TITLE
Sudocuh: Les Annulations Partielles n'invalident pas l'événement

### DIFF
--- a/nuxt/daily_dump/steps/5-interTablesToDocurbaScot.mjs
+++ b/nuxt/daily_dump/steps/5-interTablesToDocurbaScot.mjs
@@ -365,7 +365,7 @@ async function sudocuhScotToDocurba (configSource, configTraget) {
           from_sudocuh_procedure_id: event.noserieprocedure,
           type: event.libtypeevenement,
           code: event.codetypeevenement,
-          is_valid: event.codestatutevenement === 'V',
+          is_valid: event.codestatutevenement === 'V' || event.codestatutevenement === 'AP',
           date_iso: event.dateevenement,
           description: event.commentaire,
           attachements: parseAttachment(event.nomdocument),


### PR DESCRIPTION
Le script d'import des événements de Plans se comporte déjà ainsi, nous reportons ce changement pour les Schémas.

Au moment de ce commit, il y a 4 événements SCoT dans ce cas (548180, 585029, 639305, 663918). J'ai changé la valeur de `is_valid` dans ces cas.

ref https://github.com/MTES-MCT/Docurba/issues/1180