### PR TITLE
Lier les procédures à des collectivités inconnues au COG 2024

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -204,7 +204,11 @@ class Procedure(models.Model):
     type = models.CharField(blank=True, null=True)  # noqa: DJ001
     numero = models.CharField(blank=True, null=True)  # noqa: DJ001
     collectivite_porteuse = models.ForeignKey(
-        "Collectivite", models.DO_NOTHING, to_field="code_insee_unique"
+        "Collectivite",
+        models.DO_NOTHING,
+        db_constraint=False,
+        null=True,
+        to_field="code_insee_unique",
     )
     created_at = models.DateTimeField(db_default=models.functions.Now())
     doublon_cache_de = models.OneToOneField(
@@ -406,7 +410,7 @@ class Commune(Collectivite):
 
 
 class CommuneProcedure(models.Model):  # noqa: DJ008
-    commune = models.ForeignKey(Commune, models.DO_NOTHING)
+    commune = models.ForeignKey(Commune, models.DO_NOTHING, db_constraint=False)
     procedure = models.ForeignKey(Procedure, models.DO_NOTHING)
 
     class Meta:

--- a/django/core/tests/test_models.py
+++ b/django/core/tests/test_models.py
@@ -48,6 +48,21 @@ class TestProcedure:
         assert Procedure(doc_type=TypeDocument.SD).is_schema
 
     @pytest.mark.django_db
+    def test_liable_a_collectivite_porteuse_inexistante(self) -> None:
+        """Tant que l'on ne gère pas bien les communes des anciens COG."""
+        Procedure.objects.create(collectivite_porteuse_id=12)
+
+        assert Procedure.objects.count() == 1
+
+    @pytest.mark.django_db
+    def test_liable_a_commune_inexistante(self) -> None:
+        """Tant que l'on ne gère pas bien les communes des anciens COG."""
+        procedure = Procedure.objects.create()
+        procedure.perimetre.through.objects.create(commune_id=12, procedure=procedure)
+
+        assert procedure.perimetre.through.objects.count() == 1
+
+    @pytest.mark.django_db
     def test_date_approbation_retourne_plus_recent_event_approbation(
         self, django_assert_num_queries: DjangoAssertNumQueries
     ) -> None:


### PR DESCRIPTION
Comme nous n'avons actuellement pas de contraintes en base de données, il faut représenter cela dans notre modélisation.

Notamment, cela permet que `Procedure.objects.select_related('collectivite_porteuse')` utilise un `LEFT JOIN` plutôt que `INNER JOIN`