### PR TITLE
API Scots en Django

### DIFF
--- a/django/core/tests/factories.py
+++ b/django/core/tests/factories.py
@@ -1,0 +1,71 @@
+import itertools
+import random
+from typing import Any
+
+from core.models import (
+    Collectivite,
+    Commune,
+    Departement,
+    Region,
+    TypeCollectivite,
+)
+
+
+class _Auto:
+    """Sentinel value indicating an automatic default will be used."""
+
+    def __bool__(self) -> bool:
+        # Allow `Auto` to be used like `None` or `False` in boolean expressions
+        return False
+
+
+Auto: Any = _Auto()
+
+REGION_CODE_INSEE_SEQUENCE = (f"R{n}" for n in itertools.count())
+DEPARTEMENT_CODE_INSEE_SEQUENCE = (f"D{n}" for n in itertools.count())
+GROUPEMENT_CODE_INSEE_SEQUENCE = (f"G{n}" for n in itertools.count())
+
+
+def create_region(*, code_insee: str = Auto) -> Region:
+    return Region.objects.create(
+        code_insee=code_insee or next(REGION_CODE_INSEE_SEQUENCE)
+    )
+
+
+def create_departement(*, code_insee: str = Auto, region: Region = Auto) -> Departement:
+    return Departement.objects.create(
+        code_insee=code_insee or next(DEPARTEMENT_CODE_INSEE_SEQUENCE),
+        region=region or create_region(),
+    )
+
+
+def create_groupement(
+    *,
+    code_insee: str = Auto,
+    groupement_type: TypeCollectivite = Auto,
+    departement: Departement = Auto,
+) -> Collectivite:
+    code_insee = code_insee or next(GROUPEMENT_CODE_INSEE_SEQUENCE)
+    groupement_type = groupement_type or random.choice(list(TypeCollectivite))  # noqa: S311
+    return Collectivite.objects.create(
+        id=f"{code_insee}_{groupement_type}",
+        code_insee_unique=code_insee,
+        type=groupement_type,
+        departement=departement or create_departement(),
+    )
+
+
+def create_commune(
+    *,
+    code_insee: str = Auto,
+    commune_type: TypeCollectivite = Auto,
+    departement: Departement = Auto,
+) -> Commune:
+    code_insee = code_insee or next(GROUPEMENT_CODE_INSEE_SEQUENCE)
+    commune_type = commune_type or TypeCollectivite.COM
+    return Commune.objects.create(
+        id=f"{code_insee}_{commune_type}",
+        code_insee_unique=code_insee,
+        type=commune_type,
+        departement=departement or create_departement(),
+    )

--- a/django/core/urls.py
+++ b/django/core/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
         name="collectivite-detail",
     ),
     path("api/perimetres", views.api_perimetres),
+    path("api/scots", views.api_scots),
     path("__reload__/", include("django_browser_reload.urls")),
     *debug_toolbar_urls(),
     re_path(r"(?P<path>.*)", ProxyView.as_view(upstream=settings.UPSTREAM_NUXT)),

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -7,26 +7,28 @@ from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.decorators.http import require_safe
 
-from core.models import Commune
+from core.models import Collectivite, Commune, Procedure
+
+
+def _avant(request: HttpRequest) -> date | None:
+    return (
+        date.fromisoformat(request.GET.get("avant"))
+        if request.GET.get("avant")
+        else None
+    )
 
 
 @require_safe
 def api_perimetres(request: HttpRequest) -> HttpResponse:
-    departement = request.GET.get("departement")
-
     try:
-        avant = (
-            date.fromisoformat(request.GET.get("avant"))
-            if request.GET.get("avant")
-            else None
-        )
+        avant = _avant(request)
     except ValueError:
         return HttpResponseBadRequest(
             "Le paramètre 'avant' doit être une date valide au format YYYY-MM-DD."
         )
 
     communes = Commune.objects.with_procedures_principales(avant=avant)
-    if departement:
+    if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 
     response = HttpResponse(content_type="text/csv;charset=utf-8")
@@ -55,6 +57,117 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
         }
         for commune in communes.iterator(chunk_size=1000)
         for procedure in commune.procedures_principales
+    )
+    return response
+
+
+@require_safe
+def api_scots(request: HttpRequest) -> HttpResponse:
+    try:
+        avant = _avant(request)
+    except ValueError:
+        return HttpResponseBadRequest(
+            "Le paramètre 'avant' doit être une date valide au format YYYY-MM-DD."
+        )
+
+    collectivites = Collectivite.objects.portant_scot(avant=avant)
+    if departement := request.GET.get("departement"):
+        collectivites = collectivites.filter(departement__code_insee=departement)
+
+    response = HttpResponse(content_type="text/csv;charset=utf-8")
+    csv_writer = DictWriter(
+        response,
+        dialect="unix",
+        fieldnames=[
+            "annee_cog",
+            # Collectivité
+            "scot_code_region",
+            "scot_libelle_region",
+            "scot_code_departement",
+            "scot_lib_departement",
+            "scot_codecollectivite",
+            "scot_code_type_collectivite",
+            "scot_nom_collectivite",
+            # Approuvée
+            "pa_id",
+            "pa_nom_schema",
+            "pa_noserie_procedure",
+            "pa_scot_interdepartement",
+            "pa_date_publication_perimetre",
+            "pa_date_prescription",
+            "pa_date_arret_projet",
+            "pa_date_approbation",
+            "pa_annee_approbation",
+            "pa_date_fin_echeance",
+            "pa_nombre_communes",
+            # En cours
+            "pc_id",
+            "pc_nom_schema",
+            "pc_noserie_procedure",
+            "pc_proc_elaboration_revision",
+            "pc_scot_interdepartement",
+            "pc_date_publication_perimetre",
+            "pc_date_prescription",
+            "pc_date_arret_projet",
+            "pc_nombre_communes",
+        ],
+    )
+
+    def format_row(
+        collectivite: Collectivite,
+        scot_opposable: Procedure | None,
+        scot_en_cours: Procedure | None,
+    ) -> dict[str, str]:
+        champs_groupement = {
+            "annee_cog": "2024",
+            "scot_code_region": collectivite.departement.region.code_insee,
+            "scot_libelle_region": collectivite.departement.region.nom,
+            "scot_code_departement": collectivite.departement.code_insee,
+            "scot_lib_departement": collectivite.departement.nom,
+            "scot_codecollectivite": collectivite.code_insee,
+            "scot_code_type_collectivite": collectivite.type,
+            "scot_nom_collectivite": collectivite.nom,
+        }
+
+        champs_opposable = {}
+        if scot_opposable:
+            champs_opposable = {
+                "pa_id": scot_opposable.id,
+                "pa_nom_schema": scot_opposable.name,
+                "pa_noserie_procedure": scot_opposable.from_sudocuh,
+                "pa_scot_interdepartement": scot_opposable.is_interdepartemental,
+                "pa_date_publication_perimetre": scot_opposable.date_publication_perimetre,
+                "pa_date_prescription": scot_opposable.date_prescription,
+                "pa_date_arret_projet": scot_opposable.date_arret_projet,
+                "pa_date_approbation": scot_opposable.date_approbation,
+                "pa_annee_approbation": date.fromisoformat(
+                    scot_opposable.date_approbation
+                ).year,
+                "pa_date_fin_echeance": scot_opposable.date_fin_echeance,
+                "pa_nombre_communes": len(scot_opposable.communes),
+            }
+
+        champs_en_cours = {}
+        if scot_en_cours:
+            champs_en_cours = {
+                "pc_id": scot_en_cours.id,
+                "pc_nom_schema": scot_en_cours.name,
+                "pc_noserie_procedure": scot_en_cours.from_sudocuh,
+                "pc_proc_elaboration_revision": scot_en_cours.type,
+                "pc_scot_interdepartement": scot_en_cours.is_interdepartemental,
+                "pc_date_publication_perimetre": scot_en_cours.date_publication_perimetre,
+                "pc_date_prescription": scot_en_cours.date_prescription,
+                "pc_date_arret_projet": scot_en_cours.date_arret_projet,
+                "pc_nombre_communes": len(scot_en_cours.communes),
+            }
+
+        return champs_groupement | champs_opposable | champs_en_cours
+
+    csv_writer.writeheader()
+    csv_writer.writerows(
+        format_row(collectivite, scot_opposable, scot_en_cours)
+        for collectivite in collectivites.iterator(chunk_size=1000)
+        for scot_opposable, scot_en_cours in collectivite.scots_pour_csv
     )
     return response
 


### PR DESCRIPTION
- Pour les vues :
    - Factorise le traitement de la querystring pour le paramètre "avant" entre les deux routes
    - Ajoute la nouvelle route d'API
- Pour les Procédures :
    - Lit la colonne existante `from_sudocuh`
    - Ajoute `date_prescription` dans les queryset `Procedure.with_events()`
    - Ajoute le concept d'EventNotable pour les dates notables à exporter
    - Ajoute la méthode de queryset `Procedure.with_dates_notables()` pour inclure ces dates notables
    - Ajoute la propriété `Procedure.is_interdepartemental`
- Pour les Collectivités :
    - Ajoute une méthode de queryset `Collectivite.portant_scot()` pour retourner les collectivités portant un SCoT, avec toutes les données nécessaires
    - Ajoute une méthode `scots_pour_csv` permettant de retourner les SCoT d'une collectivité dans le format attendu par l'export CSV
    - Ajoute une méthode de queryset `Commune.with_scots()` pour récupérer les informations nécessaires pour déterminer si un SCoT est opposable sur au moins une commune d'une collectivité. Pour les tests :
    - Crée des factories pour faciliter l'écriture des tests
    - Ajoute des tests temporaires dans `manual_test_e2e`

ref https://github.com/MTES-MCT/Docurba/issues/1252