### PR TITLE
PAC - Permet la suppression des PJ dans plus de situations

### DIFF
--- a/nuxt/components/PAC/Sections/FileAttachmentsChips.vue
+++ b/nuxt/components/PAC/Sections/FileAttachmentsChips.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex" :style="{ gap: '0.5rem' }">
+  <div class="d-flex flex-wrap" :style="{ gap: '0.5rem' }">
     <v-chip
       v-for="file in files"
       :key="file.id"


### PR DESCRIPTION
En autorisant le retour à la ligne, on ne tronque pas le contenu des "chip", laissant apparaître le bouton de suppression dans plus de situations.

ref https://github.com/MTES-MCT/Docurba/issues/694