### PR TITLE
Premier jet de l'API communes

### DIFF
--- a/django/core/templates/collectivite.html
+++ b/django/core/templates/collectivite.html
@@ -24,6 +24,7 @@
                 <th>Nom</th>
                 <th>Opposable</th>
                 <th>Statut</th>
+                <th>Date de prescription</th>
                 <th>Date d'approbation</th>
                 <th>Denier event impactant</th>
             </tr>
@@ -38,6 +39,7 @@
                 </td>
                 <td>{% if is_opposable %}✅{% endif %}</td>
                 <td>{{ procedure.statut }}</td>
+                <td>{{ procedure.date_prescription }}</td>
                 <td>{{ procedure.date_approbation }}</td>
                 <td>{{ procedure.dernier_event_impactant.type }}</td>
             </tr>

--- a/django/core/tests/factories.py
+++ b/django/core/tests/factories.py
@@ -60,12 +60,20 @@ def create_commune(
     code_insee: str = Auto,
     commune_type: TypeCollectivite = Auto,
     departement: Departement = Auto,
+    intercommunalite: Collectivite | None = Auto,
+    nouvelle: Commune = Auto,
 ) -> Commune:
     code_insee = code_insee or next(GROUPEMENT_CODE_INSEE_SEQUENCE)
     commune_type = commune_type or TypeCollectivite.COM
+    intercommunalite = (
+        create_groupement() if intercommunalite is Auto else intercommunalite
+    )
+
     return Commune.objects.create(
         id=f"{code_insee}_{commune_type}",
         code_insee_unique=code_insee,
         type=commune_type,
         departement=departement or create_departement(),
+        intercommunalite=intercommunalite,
+        nouvelle=nouvelle or None,
     )

--- a/django/core/urls.py
+++ b/django/core/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
         name="collectivite-detail",
     ),
     path("api/perimetres", views.api_perimetres),
+    path("api/communes", views.api_communes),
     path("api/scots", views.api_scots),
     path("__reload__/", include("django_browser_reload.urls")),
     *debug_toolbar_urls(),

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.decorators.http import require_safe
 
-from core.models import Collectivite, Commune, Procedure
+from core.models import Collectivite, Commune, Procedure, TypeCollectivite
 
 
 def _avant(request: HttpRequest) -> date | None:
@@ -57,6 +57,208 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
         }
         for commune in communes.iterator(chunk_size=1000)
         for procedure in commune.procedures_principales
+    )
+    return response
+
+
+@require_safe
+def api_communes(request: HttpRequest) -> HttpResponse:
+    try:
+        avant = _avant(request)
+    except ValueError:
+        return HttpResponseBadRequest(
+            "Le paramètre 'avant' doit être une date valide au format YYYY-MM-DD."
+        )
+
+    communes = (
+        Commune.objects.filter(type=TypeCollectivite.COM)
+        .with_procedures_principales(avant=avant)
+        .csv_prefetch()
+    )
+    if departement := request.GET.get("departement"):
+        communes = communes.filter(departement__code_insee=departement)
+
+    response = HttpResponse(content_type="text/csv;charset=utf-8")
+    csv_writer = DictWriter(
+        response,
+        dialect="unix",
+        fieldnames=[
+            "annee_cog",
+            "code_insee",
+            "com_nom",
+            "com_code_departement",
+            "com_nom_departement",
+            "com_code_region",
+            "com_nom_region",
+            "com_nouvelle",
+            "epci_reg",
+            "epci_region",
+            "epci_dept",
+            "epci_departement",
+            "epci_type",
+            "epci_nom",
+            "epci_siren",
+            # "collectivite_porteuse",
+            # "cp_type",
+            # "cp_code_region",
+            # "cp_lib_region",
+            # "cp_code_departement",
+            # "cp_nom_departement",
+            # "cp_nom",
+            # "cp_siren",
+            # "cp_code_insee",
+            # "plan_code_etat_simplifie",
+            # "plan_libelle_code_etat_simplifie",
+            # "plan_code_etat_complet",
+            # "plan_libelle_code_etat_complet",
+            # "types_pc",
+            # En cours
+            "pc_docurba_id",
+            "pc_num_procedure_sudocuh",
+            "pc_nb_communes",
+            "pc_type_document",
+            "pc_type_procedure",
+            "pc_date_prescription",
+            "pc_date_arret_projet",
+            "pc_date_pac",
+            "pc_date_pac_comp",
+            "pc_plui_valant_scot",
+            # "pc_pluih",
+            # "pc_sectoriel",
+            # "pc_pdu_tient_lieu",
+            "pc_pdu_obligatoire",
+            "pc_nom_sst",
+            "pc_cout_sst_ht",
+            "pc_cout_sst_ttc",
+            # Approuvée
+            "pa_docurba_id",
+            "pa_num_procedure_sudocuh",
+            "pa_nb_communes",
+            "pa_type_document",
+            "pa_type_procedure",
+            # "pa_sectoriel",
+            "pa_date_prescription",
+            "pa_date_arret_projet",
+            "pa_date_pac",
+            "pa_date_pac_comp",
+            "pa_date_approbation",
+            "pa_annee_prescription",
+            "pa_annee_approbation",
+            "pa_date_executoire",
+            "pa_delai_approbation",
+            "pa_plui_valant_scot",
+            # "pa_pluih",
+            # "pa_pdu_tient_lieu",
+            "pa_pdu_obligatoire",
+            "pa_nom_sst",
+            "pa_cout_sst_ht",
+            "pa_cout_sst_ttc",
+        ],
+    )
+
+    def format_row(commune: Commune) -> dict[str, str]:
+        champs_commune = {
+            "annee_cog": "2024",
+            "code_insee": commune.code_insee_unique,
+            "com_nom": commune.nom,
+            "com_code_departement": commune.departement.code_insee,
+            "com_nom_departement": commune.departement.nom,
+            "com_code_region": commune.departement.region.code_insee,
+            "com_nom_region": commune.departement.region.nom,
+            "com_nouvelle": commune.is_nouvelle,
+        }
+
+        champs_intercommunalite = {}
+        if intercommunalite := commune.intercommunalite:
+            champs_intercommunalite = {
+                "epci_reg": intercommunalite.departement.region.code_insee,
+                "epci_region": intercommunalite.departement.region.nom,
+                "epci_dept": intercommunalite.departement.code_insee,
+                "epci_departement": intercommunalite.departement.nom,
+                "epci_type": intercommunalite.type,
+                "epci_nom": intercommunalite.nom,
+                "epci_siren": intercommunalite.code_insee,
+            }
+        # "collectivite_porteuse": "collectivitePorteuse",  const collectivitePorteuse = (planCurrent || planOpposable)?.collectivite_porteuse_id || commune.code
+        # "cp_type": "porteuse.type",  # noqa: ERA001
+        # "cp_code_region": "porteuse.regionCode",  # noqa: ERA001
+        # "cp_lib_region": "porteuse.departement.region.intitule",  # noqa: ERA001
+        # "cp_code_departement": "porteuse.departementCode",  # noqa: ERA001
+        # "cp_nom_departement": "porteuse.departement.intitule",  # noqa: ERA001
+        # "cp_nom": "porteuse.intitule",  # noqa: ERA001
+        # "cp_siren": "porteuse.siren",  # noqa: ERA001
+        # "cp_code_insee": "porteuse.insee",  # noqa: ERA001
+        # "plan_code_etat_simplifie": "sudocuhCodes.etat.code",  # noqa: ERA001
+        # "plan_libelle_code_etat_simplifie": "sudocuhCodes.etat.label",  # noqa: ERA001
+        # "plan_code_etat_complet": "sudocuhCodes.bcsi.code",  # noqa: ERA001
+        # "plan_libelle_code_etat_complet": "sudocuhCodes.bcsi.label",  # noqa: ERA001
+        # "types_pc": "currentsDocTypes",  # noqa: ERA001
+
+        champs_en_cours = {}
+        if plan_en_cours := commune.plan_en_cours:
+            champs_en_cours = {
+                "pc_docurba_id": plan_en_cours.id,
+                "pc_num_procedure_sudocuh": plan_en_cours.from_sudocuh,
+                "pc_nb_communes": len(plan_en_cours.perimetre_prefetched),
+                "pc_type_document": plan_en_cours.type_document,
+                "pc_type_procedure": plan_en_cours.type,
+                "pc_date_prescription": plan_en_cours.date_prescription,
+                "pc_date_arret_projet": plan_en_cours.date_arret_projet,
+                "pc_date_pac": plan_en_cours.date_porter_a_connaissance,
+                "pc_date_pac_comp": plan_en_cours.date_porter_a_connaissance_complementaire,
+                "pc_plui_valant_scot": plan_en_cours.vaut_SCoT,
+                # "pc_pluih": "planCurrent.is_pluih",  # noqa: ERA001
+                # "pc_sectoriel": "planCurrent.isSectoriel",  # noqa: ERA001
+                # "pc_pdu_tient_lieu": "planCurrent.is_pdu",  # noqa: ERA001
+                "pc_pdu_obligatoire": plan_en_cours.obligation_PDU,
+                "pc_nom_sst": plan_en_cours.maitrise_d_oeuvre
+                and plan_en_cours.maitrise_d_oeuvre["nomprestaexterne"],
+                "pc_cout_sst_ht": plan_en_cours.maitrise_d_oeuvre
+                and plan_en_cours.maitrise_d_oeuvre["coutplanht"],
+                "pc_cout_sst_ttc": plan_en_cours.maitrise_d_oeuvre
+                and plan_en_cours.maitrise_d_oeuvre["coutplanttc"],
+            }
+
+        champs_opposable = {}
+        if plan_opposable := commune.plan_opposable:
+            champs_opposable = {
+                "pa_docurba_id": plan_opposable.id,
+                "pa_num_procedure_sudocuh": plan_opposable.from_sudocuh,
+                "pa_nb_communes": len(plan_opposable.perimetre_prefetched),
+                "pa_type_document": plan_opposable.type_document,
+                "pa_type_procedure": plan_opposable.type,
+                # "pa_sectoriel": plan_opposable.is_sectoriel,  # noqa: ERA001
+                "pa_date_prescription": plan_opposable.date_prescription,
+                "pa_date_arret_projet": plan_opposable.date_arret_projet,
+                "pa_date_pac": plan_opposable.date_porter_a_connaissance,
+                "pa_date_pac_comp": plan_opposable.date_porter_a_connaissance_complementaire,
+                "pa_date_approbation": plan_opposable.date_approbation,
+                "pa_annee_prescription": plan_opposable.date_prescription
+                and plan_opposable.date_prescription.year,
+                "pa_annee_approbation": plan_opposable.date_approbation.year,
+                "pa_date_executoire": plan_opposable.date_caractere_executoire,
+                "pa_delai_approbation": plan_opposable.delai_d_approbation,
+                "pa_plui_valant_scot": plan_opposable.vaut_SCoT,
+                # "pa_pluih": "planOpposable.is_pluih",  # noqa: ERA001
+                # "pa_pdu_tient_lieu": "planOpposable.is_pdu",  # noqa: ERA001
+                "pa_pdu_obligatoire": plan_opposable.obligation_PDU,
+                "pa_nom_sst": plan_opposable.maitrise_d_oeuvre
+                and plan_opposable.maitrise_d_oeuvre["nomprestaexterne"],
+                "pa_cout_sst_ht": plan_opposable.maitrise_d_oeuvre
+                and plan_opposable.maitrise_d_oeuvre["coutplanht"],
+                "pa_cout_sst_ttc": plan_opposable.maitrise_d_oeuvre
+                and plan_opposable.maitrise_d_oeuvre["coutplanttc"],
+            }
+        return (
+            champs_commune
+            | champs_intercommunalite
+            | champs_opposable
+            | champs_en_cours
+        )
+
+    csv_writer.writeheader()
+    csv_writer.writerows(
+        format_row(commune) for commune in communes.iterator(chunk_size=1000)
     )
     return response
 


### PR DESCRIPTION
- Lors de la comparaison avec l'API actuelle, nous avons remarqué que si un abandon et une prescription ont lieu le même jour, il est préférable que les Abandons gagnent sur les Prescriptions.
- Ajout des événements qui doivent être catégorisés et l'accesseur de leur date pour utilisation par le CSV.
- Modélisation des colonnes `Procedure.vaut_SCoT`, `Procedure.obligation_PDU` et `Procedure.maitrise_d_oeuvre`.
- Ajout de `delai_d_approbation`.
- Ajout de `Procedure.__lt__` pour centraliser le tri des procédures.
- Ajout de `Commune.is_nouvelle`, `Commune.procedures_principales_en_cours`, `Commune.plan_en_cours`

Tests :
- Ajout de `intercommunalite` et `is_nouvelle` à la factory `create_commune`
- `TestCommuneOpposabilite.test_ignore_event_apres()` utilise `set(commune.procedures_principales)` car il n'y a plus de garantie de l'ordre en sortie de base de données. Le tri est reporté dans `procedures_principales_approuvees` et `procedures_principales_en_cours`.

ref https://github.com/MTES-MCT/Docurba/issues/1253