### PR TITLE
Création procédure - Cache la ligne complète pour le numéro

### DIFF
--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -89,8 +89,8 @@
             </v-col>
           </template>
         </v-row>
-        <v-row>
-          <v-col v-if="procedureCategory === 'secondaire' || typeProcedure === 'Révision'" cols="6" class="d-flex align-start">
+        <v-row v-if="procedureCategory === 'secondaire' || typeProcedure === 'Révision'">
+          <v-col cols="6" class="d-flex align-start">
             <v-text-field v-model="numberProcedure" filled placeholder="Ex. 4" label="Numéro de procédure" />
           </v-col>
           <v-col cols="6">


### PR DESCRIPTION
https://github.com/MTES-MCT/Docurba/pull/1378 a introduit un bug en affichant systématiquement le message d'aide lié aux numéros de procédures. Alors que les procédures principales n'ont pas de numéro.

ref https://github.com/MTES-MCT/Docurba/issues/1301