### PR TITLE
Email validation compte reçoit la bonne procédure partagée

### DIFF
--- a/nuxt/server-middleware/modules/admin.js
+++ b/nuxt/server-middleware/modules/admin.js
@@ -19,7 +19,7 @@ module.exports = {
       const profile = profiles[0]
       const { firstname, lastname, departement, region } = profile
       const regionData = regions.find(r => r.code === region)
-      const sharedProcedureUrl = await sharing.hasProcedureShared(profile.email)
+      const sharedProcedureUrl = await sharing.latestProcedurePrincipaleSharedUrl(profile.email)
 
       sendgrid.sendEmail({
         to: userData.email,

--- a/nuxt/server-middleware/slack.js
+++ b/nuxt/server-middleware/slack.js
@@ -169,7 +169,7 @@ async function collectiviteValidation (data, responseUrl) {
     const profile = profiles[0]
     const collectivite = geo.getCollectivite(profile.collectivite_id)
 
-    const sharedProcedureUrl = await sharing.hasProcedureShared(data.email)
+    const sharedProcedureUrl = await sharing.latestProcedurePrincipaleSharedUrl(data.email)
     sendgrid.sendEmail({
       to: profile.email,
       template_id: 'd-0143010573f6497b86abbd4e4c96f46e',


### PR DESCRIPTION
Le code existant retournait toujours une URL, que le compte ait une procédure partagée ou non. Il ne fonctionnait aussi pas si un compte avait plusieurs procédures qui lui avaient été partagées.

- Retourne undefined si un compte n'a eu aucune procédure partagée
- Sinon Retourne la procédure principale du projet associé au partage le plus récent
- Renomme la fonction pour mieux décrire ce qu'elle fait