### PR TITLE
Refactorise la récupération des dates d'une procédure

### DIFF
--- a/django/core/templates/collectivite.html
+++ b/django/core/templates/collectivite.html
@@ -39,7 +39,7 @@
                 <td>{% if is_opposable %}✅{% endif %}</td>
                 <td>{{ procedure.statut }}</td>
                 <td>{{ procedure.date_approbation }}</td>
-                <td>{{ procedure.dernier_event_impactant }}</td>
+                <td>{{ procedure.dernier_event_impactant.type }}</td>
             </tr>
             {% endfor %}
         </table>

--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -40,7 +40,7 @@ class TestAPIPerimetres:
             doc_type=TypeDocument.PLU, collectivite_porteuse=commune
         )
 
-        with django_assert_num_queries(2):
+        with django_assert_num_queries(3):
             response = client.get(
                 "/api/perimetres", {"departement": commune.departement.code_insee}
             )
@@ -128,7 +128,7 @@ class TestAPIScots:
         groupement = create_groupement()
         scot_en_cours = groupement.procedure_set.create(doc_type=TypeDocument.SCOT)
 
-        with django_assert_num_queries(3):
+        with django_assert_num_queries(4):
             response = client.get("/api/scots")
 
         assert response.status_code == 200
@@ -166,7 +166,7 @@ class TestAPIScots:
                 "pc_proc_elaboration_revision": "",
                 "pc_scot_interdepartement": "False",
                 "pc_date_publication_perimetre": "",
-                "pc_date_prescription": "0000-00-00",
+                "pc_date_prescription": "",
                 "pc_date_arret_projet": "",
                 "pc_nombre_communes": "0",
             }

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -140,9 +140,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
                 "pa_date_prescription": scot_opposable.date_prescription,
                 "pa_date_arret_projet": scot_opposable.date_arret_projet,
                 "pa_date_approbation": scot_opposable.date_approbation,
-                "pa_annee_approbation": date.fromisoformat(
-                    scot_opposable.date_approbation
-                ).year,
+                "pa_annee_approbation": scot_opposable.date_approbation.year,
                 "pa_date_fin_echeance": scot_opposable.date_fin_echeance,
                 "pa_nombre_communes": len(scot_opposable.communes),
             }


### PR DESCRIPTION
Plutôt que de faire des requêtes SQL avancées, on récupère tous les événements que l'on classifie ensuite en Python.

Quand plusieurs événements ont la même date, cela nous permet de privilégier certaines catégories (`EVENT_CATEGORY_PRIORISES`).

Refactoring :

-   Fusionne `EventImpact` et `EventNotable` vers `EventCategory`.
-   Supprime `EventCategory.DELIBERATION` qui n'est pas utilisée.
-   Renomme `EventCategory.EN_COURS` en `EventCategory.PRESCRIPTION`.
-   Supprime `ProcedureQuerySet.with_dates_notables()` qui n'est plus utilisée.
-   `ProcedureQuerySet.with_events` n'est plus automatique sur `ProcedureManager` car cela déclenchait l'erreur suivante lorsqu'on l'utilisait deux fois :
    -   `ValueError: 'events_prefetched' lookup was already seen with a different queryset. You may need to adjust the ordering of your lookups.`
-   Toutes les dates précédemment extraites via `annotate` sont disponibles via des `@property`. Idem pour `dernier_event_impactant` mais qui passe d'une string `event_type` à un objet `Event` complet.
-   Le tri des procédures par date d'approbation ne pouvant plus être fait en SQL, il est fait en Python dans `Commune.procedures_principales_approuvees()`.

Tests ajoutés :

-   `dernier_event_impactant`
-   `test_approuvee_quand_prescription_et_approbation_meme_jour` et `test_prescrite_quand_prescription_et_abandon_meme_jour`
-   `test_event_sans_date_ignore`

Adaptation des Tests :

-   Tous les tests créant des événements le font maintenant avec une date.
-   Le nombre de queries est augmenté.
-   Suppression du test lié à `with_dates_notables()`.
-   Fusion des tests `TestProcedureDateImpactantes` et `TestProcedureDatesNotables`.
-   Renommages liés à `EventCategory`.

fix https://github.com/MTES-MCT/Docurba/issues/1387