### PR TITLE
PAC - Rétablit la consultation, / manquant

### DIFF
--- a/nuxt/server-middleware/modules/github/files.js
+++ b/nuxt/server-middleware/modules/github/files.js
@@ -5,7 +5,7 @@ async function getFileContent (path, ref, format = 'raw') {
   // console.log('Get File', format, path)
 
   try {
-    const { data: file } = await github(`GET /repos/{owner}/{repo}/contents${encodeURIComponent(path)}?ref=${ref}`, {
+    const { data: file } = await github(`GET /repos/{owner}/{repo}/contents/${encodeURIComponent(path)}?ref=${ref}`, {
       path,
       mediaType: {
         format
@@ -18,7 +18,7 @@ async function getFileContent (path, ref, format = 'raw') {
   } catch (err) {
     // If a file was saved as intro instead of intro.md we have this fail safe.
     // Need to clean all the branches to change that.
-    const { data: file } = await github(`GET /repos/{owner}/{repo}/contents${encodeURIComponent(path.replace('.md', ''))}?ref=${ref}`, {
+    const { data: file } = await github(`GET /repos/{owner}/{repo}/contents/${encodeURIComponent(path.replace('.md', ''))}?ref=${ref}`, {
       path,
       mediaType: {
         format
@@ -32,7 +32,7 @@ async function getFileContent (path, ref, format = 'raw') {
 }
 
 async function getFiles (path, ref, fetchContent = false) {
-  let { data: repo } = await github(`GET /repos/{owner}/{repo}/contents${encodeURIComponent(path)}?ref=${ref}`, {
+  let { data: repo } = await github(`GET /repos/{owner}/{repo}/contents/${encodeURIComponent(path)}?ref=${ref}`, {
     path
   })
 


### PR DESCRIPTION
Pour une raison que nous ne connaissons pas, depuis le 23 ou 24 juillet, la consultation des PAC ne fonctionne plus.

On soupçonne un parsing plus strict des URLs côté Github.

La table `github_cache` contient des entrées du type `GET /repos/{owner}/{repo}/contentsPAC%2FDispositions` depuis au moins un an. Elles auraient dû contenir un `/` entre `contents` et `PAC`. C'est ce que fait ce patch.

D'ailleurs, les URLs ne devraient pas être construites ainsi mais ce n'est pas un changement facile car il impacterait la clef de cache.