### PR TITLE
API - Optimisation des index avec varchar_pattern_ops

### DIFF
--- a/django/core/migrations/0004_viewcommuneadhesionsdeep.py
+++ b/django/core/migrations/0004_viewcommuneadhesionsdeep.py
@@ -37,10 +37,10 @@ GROUP BY
 """
 
 CREATE_INDEX_FROM_COLLECTIVITE = """
-CREATE INDEX IF NOT EXISTS view_commune_adhesions_deep_commune_id_idx ON view_commune_adhesions_deep (commune_id) include (groupement_id)
+CREATE INDEX IF NOT EXISTS view_commune_adhesions_deep_commune_id_idx ON view_commune_adhesions_deep (commune_id varchar_pattern_ops) include (groupement_id)
 """
 CREATE_INDEX_TO_COLLECTIVITE = """
-CREATE INDEX IF NOT EXISTS view_commune_adhesions_deep_groupement_id_idx ON view_commune_adhesions_deep (groupement_id) include (commune_id)
+CREATE INDEX IF NOT EXISTS view_commune_adhesions_deep_groupement_id_idx ON view_commune_adhesions_deep (groupement_id varchar_pattern_ops) include (commune_id)
 """
 
 DROP_VIEW = "DROP MATERIALIZED VIEW if EXISTS view_commune_adhesions_deep"

--- a/django/core/migrations/0005_commune_collectivite_nouvelle_null_idx.py
+++ b/django/core/migrations/0005_commune_collectivite_nouvelle_null_idx.py
@@ -16,6 +16,7 @@ class Migration(migrations.Migration):
                 condition=models.Q(("nouvelle__isnull", True)),
                 fields=["collectivite_ptr"],
                 name="collectivite_nouvelle_null_idx",
+                opclasses=["varchar_pattern_ops"],
             ),
         ),
     ]

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -632,6 +632,7 @@ class Commune(Collectivite):
                 fields=["collectivite_ptr"],
                 condition=models.Q(nouvelle__isnull=True),
                 name="collectivite_nouvelle_null_idx",
+                opclasses=["varchar_pattern_ops"],
             ),
         )
 


### PR DESCRIPTION
L'Index Scan est plus rapide avec ce type d'opclass.

Les index ont déjà été appliqués en production, d'où la modification des migrations existantes.

ref https://github.com/MTES-MCT/Docurba/issues/1253 ref https://github.com/MTES-MCT/Docurba/issues/1227 ref https://github.com/MTES-MCT/Docurba/issues/1252