### PR TITLE
API communes - Codes état

### DIFF
--- a/django/core/tests/manual_test_e2e.py
+++ b/django/core/tests/manual_test_e2e.py
@@ -796,6 +796,10 @@ class TestCommunes:
                 "cp_nom",
                 "cp_siren",
                 "cp_code_insee",
+                "plan_code_etat_simplifie",
+                "plan_libelle_code_etat_simplifie",
+                "plan_code_etat_complet",
+                "plan_libelle_code_etat_complet",
                 # En cours
                 "pc_docurba_id",
                 "pc_num_procedure_sudocuh",
@@ -833,12 +837,12 @@ class TestCommunes:
             if django_row["pc_date_prescription"] == "0000-00-00":
                 django_row["pc_date_prescription"] = ""
             nuxt_row = {  # noqa: PLW2901
-                k: str(v or "").capitalize()
+                k: str(v or "").capitalize().strip()
                 for k, v in nuxt_row.items()
                 if k in colonnes_filtrees
             }
             django_row = {  # noqa: PLW2901
-                k: str(v or "").capitalize()
+                k: str(v or "").capitalize().strip()
                 for k, v in django_row.items()
                 if k in colonnes_filtrees
             }

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -111,10 +111,10 @@ def api_communes(request: HttpRequest) -> HttpResponse:
             "cp_nom",
             "cp_siren",
             "cp_code_insee",
-            # "plan_code_etat_simplifie",
-            # "plan_libelle_code_etat_simplifie",
-            # "plan_code_etat_complet",
-            # "plan_libelle_code_etat_complet",
+            "plan_code_etat_simplifie",
+            "plan_libelle_code_etat_simplifie",
+            "plan_code_etat_complet",
+            "plan_libelle_code_etat_complet",
             # "types_pc",
             # En cours
             "pc_docurba_id",
@@ -183,10 +183,10 @@ def api_communes(request: HttpRequest) -> HttpResponse:
             "cp_code_insee": commune.collectivite_porteuse.code_insee
             if commune.collectivite_porteuse.is_commune
             else "",
-            # "plan_code_etat_simplifie": "sudocuhCodes.etat.code",  # noqa: ERA001
-            # "plan_libelle_code_etat_simplifie": "sudocuhCodes.etat.label",  # noqa: ERA001
-            # "plan_code_etat_complet": "sudocuhCodes.bcsi.code",  # noqa: ERA001
-            # "plan_libelle_code_etat_complet": "sudocuhCodes.bcsi.label",  # noqa: ERA001
+            "plan_code_etat_simplifie": commune.code_etat_simplifie,
+            "plan_libelle_code_etat_simplifie": commune.libelle_code_etat_simplifie,
+            "plan_code_etat_complet": commune.code_etat_complet,
+            "plan_libelle_code_etat_complet": commune.libelle_code_etat_complet,
             # "types_pc": "currentsDocTypes",  # noqa: ERA001
         }
 


### PR DESCRIPTION
- Lorsque le code_etat_complet d'une commune n'a pas de libellé, nous retournons un libellé vide mais loggons une exception pour collecter ces scénarios dans Sentry.
- Bien qu'il existe des POS que l'on devrait considérer en cours, on rajoute une logique spéciale pour ne pas le faire car cela interférait avec le libellé des code_etat_simple. Nous reverrons cette situation en travaillant sur https://github.com/MTES-MCT/Docurba/issues/1174.

ref https://github.com/MTES-MCT/Docurba/issues/1253