### PR TITLE
Revert "Bannière info déplacement bouton exports"

### DIFF
--- a/nuxt/pages/ddt/_departement/procedures/index.vue
+++ b/nuxt/pages/ddt/_departement/procedures/index.vue
@@ -1,19 +1,7 @@
 <template>
   <v-container>
     <v-row>
-      <v-col cols="12">
-        <v-alert type="info" text class="mb-0">
-          L'export des communes a été déplacé dans l'onglet
-          <NuxtLink :to="`/ddt/${$route.params.departement}/collectivites`">
-            Mes collectivités
-          </NuxtLink>.
-          Suivez les nouveautés de l'outil grâce à notre
-          <a href="https://docurba.crisp.help/fr/article/les-lettres-dinfos-1t8h3i/?bust=1752738164382">
-            lettre d'info
-          </a> !
-        </v-alert>
-      </v-col>
-      <v-col cols="12" class="d-flex align-center justify-space-between pb-0 pt-0">
+      <v-col cols="12" class="d-flex align-center justify-space-between pb-0 pt-4">
         <h1>Mes Procédures</h1>
         <div>
           <v-btn depressed color="primary" :to="`/ddt/${$route.params.departement}/procedures/choix-collectivite`">


### PR DESCRIPTION
This reverts commit 5b3d50949a520c4285b8cf1e4a7cfe03063fb6b6. This reverts commit e19d5f0cdaed7a64dc996859af62b9e36c26425c.

ref https://github.com/MTES-MCT/Docurba/issues/1396