### PR TITLE
Ignorer le suivi du fichier local Mise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ pg_secret_config.mjs
 ColPorteuse.csv
 
 __pycache__
+
+# Mise
+.mise.local.toml


### PR DESCRIPTION
Mise permet de surcharger le fichier commun, suivi par Git (.mise.toml) par une version locale adaptée aux préférences de chacun.
Cette PR ajoute ce fichier à la liste des fichiers ignorés par Git. 