### PR TITLE
1245 L'événement fin d'échéance change le statut de la procédure en caduc.

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -399,6 +399,8 @@ class Procedure(models.Model):
     def statut(self) -> EventCategory | None:
         if not self.dernier_event_impactant:
             return None
+        if self.date_fin_echeance and self.date_fin_echeance < self.date_pivot:
+            return EventCategory.CADUC
         return self.dernier_event_impactant.category
 
     def _date(self, event_type: EventCategory) -> date | None:


### PR DESCRIPTION
Passé la date de Fin d'échéance, un SCoT devient caduque.

ref https://github.com/MTES-MCT/Docurba/issues/1245