### PR TITLE
Les dates de fin d'échéance ne sont pas impactées par "avant"

### DIFF
--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -112,7 +112,7 @@ class TestAPIPerimetres:
         )
 
         procedure.event_set.create(
-            type="Délibération d'approbation", date_evenement="2023-01-01"
+            type="Délibération d'approbation", date_evenement="2023-01-02"
         )
 
         response = client.get("/api/perimetres", {"avant": avant})


### PR DESCRIPTION
Peu importe la date de la photographie, les fins d'échéance (qui sont majoritairement dans le futur par définition) sont toujours renvoyées.

Le paramètre avant devient inclusif : les événements saisis le jour même seront pris en compte.

On change aussi le comportement sans paramètre `avant`: jusqu'ici, on prenait en compte tous les événements. Maintenant, on ne prend en compte que ceux jusqu'à aujourd'hui.

L'utilisation de `annotate` est dommage (car elle touche la requête SQL générée) pour réaliser cela mais nous n'avons pas trouvé d'autre manière d'avoir une propriété sur toutes les instances retournées par une queryset.

ref https://github.com/MTES-MCT/Docurba/issues/1245