### PR TITLE
Lire la variable d'environnement DJANGO_DEBUG

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -38,7 +38,7 @@ jobs:
       - run: pytest --create-db
         env:
           SECRET_KEY: test_secret_key
-          DEBUG: "True"
+          DJANGO_DEBUG: "True"
           DATABASE_URL: postgres://postgres:docurba@localhost:5434/docurba
           UPSTREAM_NUXT: http://localhost:3000
       - run: ruff format --diff .

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = env.str("SECRET_KEY")
 
-DEBUG = env.str("DEBUG", False)
+DEBUG = env.str("DJANGO_DEBUG", False)
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[])
 


### PR DESCRIPTION
Un changement récent dans VSCode supprime la variable d'environnement
DEBUG au lancement de la commande Run Tests. Je n'ai pas trouvé de
meilleur moyen de contourner ce souci.
Cela étant, la variable d'environnement DJANGO_DEBUG est plus explicite
que simplement DEBUG et évite tout conflit éventuel avec d'autres
configurations.
