### PR TITLE
Ajout d'un order_by pour éviter les tests bagottants

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -603,6 +603,7 @@ class CollectiviteQuerySet(models.QuerySet):
                     Procedure.objects.defer("current_perimetre", "initial_perimetre")
                     .with_events(avant=avant)
                     .without_adhesions_count()
+                    .order_by("created_at")
                     .filter(
                         doc_type="SCOT",
                         parente=None,


### PR DESCRIPTION
Les tests suivants échouent aléatoirement dans la PR #1491 car il manque un `order_by` qui garantit l'ordre de la liste comparée dans les tests.  
```
FAILED core/tests/test_models.py::TestCollectivitePortantScot::test_retourne_scot_opposables_des_qu_une_commune_considere_opposable - assert [(<Procedure:...SCOT >, None)] == [(<Procedure:...SCOT >, None)]
FAILED core/tests/test_models.py::TestCollectivitePortantScot::test_retourne_le_meme_scot_en_cours_pour_chaque_opposable - assert [(<Procedure:...None  SCOT >)] == [(<Procedure:...None  SCOT >)]
```

exemple : https://github.com/MTES-MCT/Docurba/actions/runs/18090932926/job/51471140840

Quand la PR sur l'ajout d'usines sera en prod (#1517 ), ajouter les tests suivants à cette PR : https://github.com/MTES-MCT/Docurba/pull/1491/commits/f2eac83e2d8cd450c7c0a5f70fb1394a53bbd52f

