### PR TITLE
Faire référence au nom des URL au lieu de leur valeur

### DIFF
--- a/django/core/tests/manual_test_e2e.py
+++ b/django/core/tests/manual_test_e2e.py
@@ -10,6 +10,7 @@ import pytest
 from django.conf import settings
 from django.db import connections
 from django.test import Client
+from django.urls import reverse
 from environ import Env
 from pytest_django import DjangoAssertNumQueries
 
@@ -403,7 +404,7 @@ class TestScots:
         nuxt = self._retrieve_nuxt("/api/urba/exports/scots")
 
         with django_assert_num_queries(4):
-            response = client.get("/api/scots")
+            response = client.get(reverse("api_scots"))
 
         django = pl.read_csv(
             response.content,

--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -3,6 +3,7 @@ from itertools import product
 
 import pytest
 from django.test import Client
+from django.urls import reverse
 from pytest_django import DjangoAssertNumQueries
 
 from core.models import TypeDocument
@@ -17,7 +18,7 @@ class TestAPI:
         ("invalid_avant", "path"),
         product(
             ("2023-1-01", "2023-02-30", "invalid-date", "2023/01/01"),
-            ("/api/perimetres", "/api/scots"),
+            ("/api/perimetres", reverse("api_scots")),
         ),
     )
     def test_parsing_avant(self, client: Client, invalid_avant: str, path: str) -> None:
@@ -267,7 +268,7 @@ class TestAPIScots:
         )
 
         with django_assert_num_queries(4):
-            response = client.get("/api/scots")
+            response = client.get(reverse("api_scots"))
 
         assert response.status_code == 200
         assert response["content-type"] == "text/csv;charset=utf-8"
@@ -326,7 +327,7 @@ class TestAPIScots:
         )
 
         response = client.get(
-            "/api/scots", {"departement": groupement_a.departement.code_insee}
+            reverse("api_scots"), {"departement": groupement_a.departement.code_insee}
         )
         reader = DictReader(response.content.decode().splitlines())
         assert len(list(reader)) == 1
@@ -346,7 +347,7 @@ class TestAPIScots:
             type="Publication périmètre", date_evenement="2024-12-01"
         )
 
-        response = client.get("/api/scots")
+        response = client.get(reverse("api_scots"))
         reader = DictReader(response.content.decode().splitlines())
         assert len(list(reader)) == 2
 
@@ -373,7 +374,7 @@ class TestAPIScots:
             type="Délibération d'approbation", date_evenement="2024-01-01"
         )
 
-        response = client.get("/api/scots", {"avant": avant})
+        response = client.get(reverse("api_scots"), {"avant": avant})
 
         reader = DictReader(response.content.decode().splitlines())
         assert [collectivite[champ_procedure_id] for collectivite in reader] == [

--- a/django/core/urls.py
+++ b/django/core/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     ),
     path("api/perimetres", views.api_perimetres),
     path("api/communes", views.api_communes),
-    path("api/scots", views.api_scots),
+    path("api/scots", views.api_scots, name="api_scots"),
     path("__reload__/", include("django_browser_reload.urls")),
     *debug_toolbar_urls(),
     path(  # Désactive le websocket hot reload Nuxt en dev


### PR DESCRIPTION
Cela évite de mettre à jour toutes les valeurs lors de leur changement.
Cela permet également de mieux identifier les applications auxquelles
sont intégrées les URL (avec des espaces de nom même si ce n'est pas
encore utile aujourd'hui puisque nous n'avons qu'une seule application).

https://docs.djangoproject.com/en/5.2/topics/http/urls/#reverse-resolution-of-urls

Pour l'instant, je n'ai touché qu'à la vue api_scots car c'est la seule
dont j'avais besoin pour la PR sur les zones blanches mais je pourrais
faire une passe sur les autres.

