### PR TITLE
Bloquer Google tag manager en local

### DIFF
--- a/nuxt/components/VConsentSnackbar.vue
+++ b/nuxt/components/VConsentSnackbar.vue
@@ -45,7 +45,7 @@ export default {
         this.opened = true
       } else {
         this.opened = false
-        if (consent === `${cookieConsentValue}-true`) {
+        if (consent === `${cookieConsentValue}-true` && !process.dev) {
           this.$gtag()
         }
       }


### PR DESCRIPTION
Il faudrait aussi désactiver les appels à Matomo mais je n'ai pas encore trouvé comment le faire proprement.
Note pour moi-même : n'activer Matomo que sur l'environnement de prod.
