### PR TITLE
Ajout d'une bannière indiquant l'environnement

### DIFF
--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -222,7 +222,8 @@ jobs:
         SUPABASE_ANON_KEY="${{ steps.db.outputs.SUPABASE_ANON_KEY }}" \
         NUXT3_API_URL="${{ needs.prepare.outputs.NUXT_3_URL }}" \
         APP_URL="${{ needs.prepare.outputs.DJANGO_URL }}" \
-        DJANGO_API_BASE_URL="${{ needs.prepare.outputs.DJANGO_URL }}"
+        DJANGO_API_BASE_URL="${{ needs.prepare.outputs.DJANGO_URL }}" \
+        USER_ENVIRONMENT="review_app"
 
     - name: Déploiement de l'application
       run: scalingo --app "${{ needs.prepare.outputs.NUXT_2_REVIEW_APP_NAME }}" integration-link-manual-deploy "${{ env.BRANCH }}"  &> /dev/null

--- a/nuxt/.env.example
+++ b/nuxt/.env.example
@@ -4,11 +4,8 @@ export SUPABASE_URL="http://127.0.0.1:54321"
 # APP_URL is used in emails and Slack webhooks to provide the full path to our app, including the domain name.
 # As Django acts as a proxy to our app, APP_URL points to its address.
 export APP_URL="http://localhost:3000" # without the trailing slash
-# Only used in review apps to provide Nuxt's domain name to Django.
-export NUXT_URL="https://nuxtserver.domain.com"
 export NUXT3_API_URL="http://localhost:4000" # without the trailing slash
 export DJANGO_API_BASE_URL="http://localhost:8000"
-export NODE_ENV="development" # available values: ['production', 'development']
 export USER_ENVIRONMENT="development" # available values: ['production', 'development', 'review_app', 'demo']
 
 # Not mandatory environment variables.

--- a/nuxt/.env.example
+++ b/nuxt/.env.example
@@ -9,6 +9,7 @@ export NUXT_URL="https://nuxtserver.domain.com"
 export NUXT3_API_URL="http://localhost:4000" # without the trailing slash
 export DJANGO_API_BASE_URL="http://localhost:8000"
 export NODE_ENV="development" # available values: ['production', 'development']
+export USER_ENVIRONMENT="development" # available values: ['production', 'development', 'review_app', 'demo']
 
 # Not mandatory environment variables.
 export BREVO_API_KEY=""

--- a/nuxt/.env.example
+++ b/nuxt/.env.example
@@ -8,6 +8,7 @@ export APP_URL="http://localhost:3000" # without the trailing slash
 export NUXT_URL="https://nuxtserver.domain.com"
 export NUXT3_API_URL="http://localhost:4000" # without the trailing slash
 export DJANGO_API_BASE_URL="http://localhost:8000"
+export NODE_ENV="development" # available values: ['production', 'development']
 
 # Not mandatory environment variables.
 export BREVO_API_KEY=""

--- a/nuxt/components/Frise/EventForm.vue
+++ b/nuxt/components/Frise/EventForm.vue
@@ -151,7 +151,7 @@ export default {
     return {
       defaultEvent,
       event: Object.assign({}, defaultEvent, {
-        description: this.$isDev ? 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.' : '',
+        description: '',
         project_id: this.procedure.project_id,
         procedure_id: this.procedure.id
       }, this.value),

--- a/nuxt/components/Layouts/AppBar.vue
+++ b/nuxt/components/Layouts/AppBar.vue
@@ -6,6 +6,7 @@
     class="app-bar"
     height="94px"
   >
+    <LayoutsEnvBanner />
     <div class="app-bar-title">
       <img src="@/assets/images/republique-francaise.svg" class="app-bar-title__logo">
       <img src="@/assets/images/republique-francaise-short.svg" class="app-bar-title__logo--short">

--- a/nuxt/components/Layouts/EnvBanner.vue
+++ b/nuxt/components/Layouts/EnvBanner.vue
@@ -1,0 +1,37 @@
+<template>
+  <div v-if="visible" class="env-banner">
+    {{ label }}
+  </div>
+</template>
+
+<script>
+import { ENVIRONMENT, ENVIRONMENT_LABEL } from '@/plugins/environement'
+
+export default {
+  computed: {
+    label () {
+      return ENVIRONMENT_LABEL[process.env.USER_ENVIRONMENT]
+    },
+    visible () {
+      return this.environment !== ENVIRONMENT.PRODUCTION
+    }
+  }
+}
+</script>
+
+<style>
+.env-banner {
+  background-color: var(--v-primary-base);
+  color: #fff;
+  display: grid;
+  left: 0;
+  padding: .5rem 4.6875rem .5rem .8125rem;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  top: 3.375rem;
+  transform: rotate(-22.5deg);
+  transform-origin: bottom left;
+  width: 15.25rem;
+}
+</style>

--- a/nuxt/components/Onboarding/SignupForm.vue
+++ b/nuxt/components/Onboarding/SignupForm.vue
@@ -91,7 +91,7 @@ export default {
         mdiEye,
         mdiEyeOff
       },
-      userData: Object.assign(this.defaultUserData(), this.$isDev ? {} : this.value)
+      userData: this.value
     }
   },
   watch: {
@@ -102,20 +102,5 @@ export default {
       }
     }
   },
-  methods: {
-    defaultUserData () {
-      return {
-        email: this.$isDev ? `fabien+${this.$dayjs().format('DD-MM-YY-hhmm')}@quantedsquare.com` : '',
-        firstname: this.$isDev ? 'Test' : '',
-        lastname: this.$isDev ? 'Test' : '',
-        password: this.$isDev ? 'docurba12345' : '',
-        poste: null,
-        other_poste: null,
-        departement: null,
-        region: null,
-        optin: false
-      }
-    }
-  }
 }
 </script>

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -10,6 +10,8 @@ export default {
     DJANGO_API_BASE_URL: process.env.DJANGO_API_BASE_URL,
     SUPABASE_URL: process.env.SUPABASE_URL,
     SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY,
+    APP_URL: process.env.APP_URL,
+    USER_ENVIRONMENT: process.env.USER_ENVIRONMENT,
   },
   head: {
     titleTemplate: '%s - Docurba',
@@ -253,22 +255,6 @@ export default {
         config.devtool = 'source-map'
       }
     }
-    // filenames: {
-    //   app: ({ isDev }) => '[name].js',
-    //   chunk: ({ isDev }) => '[name].js',
-    //   css: ({ isDev }) => '[name].css',
-    //   img: ({ isDev }) => 'img/[name].[ext]',
-    //   font: ({ isDev }) => 'fonts/[name].[ext]',
-    //   video: ({ isDev }) => 'videos/[name].[ext]'
-    // }
-    // filenames: {
-    //   app: ({ isDev }) => isDev ? '[name].js' : '[contenthash].js',
-    //   chunk: ({ isDev }) => isDev ? '[name].js' : '[contenthash].js',
-    //   css: ({ isDev }) => isDev ? '[name].css' : '[contenthash].css',
-    //   img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[contenthash:7].[ext]',
-    //   font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[contenthash:7].[ext]',
-    //   video: ({ isDev }) => isDev ? '[path][name].[ext]' : 'videos/[contenthash:7].[ext]'
-    // }
     // transpile: ['d3', 'd3-geo', 'internmap']
   }
 }

--- a/nuxt/pages/login/collectivites/signup.vue
+++ b/nuxt/pages/login/collectivites/signup.vue
@@ -147,13 +147,13 @@ export default {
       selectedCollectivite: {},
       loading: false,
       userData: {
-        email: this.$isDev ? `fabien+${this.$dayjs().format('DDMMYYhhmm')}@quantedsquare.com` : '',
-        firstname: this.$isDev ? 'Test' : '',
-        lastname: this.$isDev ? 'Test' : '',
-        poste: '', // 'elu',
-        other_poste: '', // 'test',
-        tel: this.$isDev ? '0669487499' : '', // '0669487499',
-        collectivite_id: '', // '45678'
+        email: '',
+        firstname: '',
+        lastname: '',
+        poste: '',
+        other_poste: '',
+        tel: '',
+        collectivite_id: '',
         optin: false
       },
       snackbar: {
@@ -165,8 +165,6 @@ export default {
   },
   methods: {
     async signUp () {
-      // console.log('signup')
-
       try {
         this.loading = true
         this.userData.other_poste = this.userData.other_poste ? [this.userData.other_poste] : null
@@ -184,7 +182,6 @@ export default {
             redirectTo: window.location.origin
           }
         })
-        // console.log('ret: ', ret)
         this.$router.push({
           name: 'login-collectivites-explain',
           query: { collectivite_id: this.selectedCollectivite.code }

--- a/nuxt/pages/print/_projectId.vue
+++ b/nuxt/pages/print/_projectId.vue
@@ -82,7 +82,7 @@ import orderSections from '@/mixins/orderSections.js'
 
 export default {
   layout: 'print',
-  async asyncData ({ $supAdmin, $md, route, $isDev }) {
+  async asyncData ({ $supAdmin, $md, route }) {
     const projectId = route.params.projectId
 
     if (process.server) {
@@ -90,11 +90,9 @@ export default {
         const { data: projects } = await $supAdmin.from('projects').select('*').eq('id', projectId)
         const project = projects[0]
 
-        const baseUrl = $isDev ? 'http://localhost:3000' : 'https://docurba.beta.gouv.fr'
-
         const { data: sections } = await axios({
           method: 'get',
-          url: `${baseUrl}/api/trames/tree/projet-${projectId}?content=all`
+          url: `${process.env.APP_URL}/api/trames/tree/projet-${projectId}?content=all`
         })
 
         function deptToRef (deptCode) {

--- a/nuxt/plugins/analytics.js
+++ b/nuxt/plugins/analytics.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import departements from '@/assets/data/INSEE/departements_small.json'
 
-export default ({ $supabase, $user, $isDev, app }, inject) => {
+export default ({ $supabase, $user, app }, inject) => {
   async function sendEvent (event) {
     const route = app.router.currentRoute
 
@@ -42,19 +42,15 @@ export default ({ $supabase, $user, $isDev, app }, inject) => {
       region = departements.find(d => d.code === dept).region.code
     }
 
-    // console.log('analytics', collectiviteId, dept, region)
-
-    if (!$isDev) {
-      await $supabase.from('analytics_events').insert([Object.assign({
-        user_id: $user.id,
-        path: route.path,
-        collectivite_id: collectiviteId,
-        project_id: projectId,
-        procedure_id: procedureId,
-        dept,
-        region
-      }, event)])
-    }
+    await $supabase.from('analytics_events').insert([Object.assign({
+      user_id: $user.id,
+      path: route.path,
+      collectivite_id: collectiviteId,
+      project_id: projectId,
+      procedure_id: procedureId,
+      dept,
+      region
+    }, event)])
   }
 
   inject('analytics', sendEvent)

--- a/nuxt/plugins/environement.js
+++ b/nuxt/plugins/environement.js
@@ -1,0 +1,13 @@
+export const ENVIRONMENT = {
+  DEMO: 'demo',
+  DEVELOPMENT: 'development',
+  PRODUCTION: 'production',
+  REVIEW_APP: 'review_app'
+}
+
+export const ENVIRONMENT_LABEL = {
+  [ENVIRONMENT.DEMO]: 'Démonstration',
+  [ENVIRONMENT.DEVELOPMENT]: 'Développement',
+  [ENVIRONMENT.PRODUCTION]: 'Production',
+  [ENVIRONMENT.REVIEW_APP]: 'Recette jetable'
+}

--- a/nuxt/plugins/isDev.js
+++ b/nuxt/plugins/isDev.js
@@ -1,3 +1,3 @@
 export default (_, inject) => {
-  inject('isDev', process.env.NODE_ENV === 'development')
+  inject('isDev', process.env.USER_ENVIRONMENT === 'development')
 }

--- a/nuxt/scalingo.json
+++ b/nuxt/scalingo.json
@@ -1,15 +1,9 @@
 {
   "name": "Nuxt review apps",
-  "env": {
-    "NUXT_URL": {
-      "description": "URL of the application",
-      "generator": "url"
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "M"
     }
-  },
-    "formation": {
-        "web": {
-            "amount": 1,
-            "size": "M"
-        }
-    }
+  }
 }

--- a/nuxt/server-middleware/auth.js
+++ b/nuxt/server-middleware/auth.js
@@ -63,7 +63,6 @@ async function magicLinkSignIn ({ email, redirectBasePath }) {
     })
 
     if (error) {
-      console.log('ERROR magicLinkSignIn: ', error)
       throw error
     }
 
@@ -75,7 +74,6 @@ async function magicLinkSignIn ({ email, redirectBasePath }) {
           redirectURL: properties.action_link,
           firstname: profile.firstname,
           lastname: profile.lastname
-          // dashboard_url: `https://docurba.beta.gouv.fr/collectivites/${profile.collectivite_id}/`
         }
       })
     }
@@ -124,7 +122,6 @@ app.post('/signupCollectivite', async (req, res) => {
     }).select()
 
     if (errorInsertProfile) {
-      // console.log('Error in profile creation', errorInsertProfile)
       throw errorInsertProfile
     }
 

--- a/nuxt/server-middleware/modules/pipedrive.js
+++ b/nuxt/server-middleware/modules/pipedrive.js
@@ -116,10 +116,18 @@ module.exports = {
     }
   },
   async getPersonDeals (idPerson) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const { data: personDeals } = await personsApi.getPersonDeals(idPerson)
     return personDeals
   },
   async findOrganization (departementNumber) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const {
       data: organizationsData,
       success: successOrg
@@ -147,6 +155,10 @@ module.exports = {
     } else { console.log('organizationsError') }
   },
   async addOrganization (departementNumber) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const newOrganization = pipedrive.NewOrganization.constructFromObject({
       name: `DDT ${departementNumber}`
     })
@@ -158,6 +170,10 @@ module.exports = {
     } else { console.log(error) }
   },
   async findPerson (email) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     try {
       const { data: personsData, error: personsError } = await personsApi.searchPersons(email, {
         fields: 'email',
@@ -192,7 +208,10 @@ module.exports = {
     }
   },
   async addPerson (userData) {
-    // console.log(' addPerson userData: ', userData)
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const personData = pipedrive.NewPerson.constructFromObject({
       name: `${userData.firstname} ${userData.lastname}`,
       phone: [{
@@ -218,6 +237,10 @@ module.exports = {
     } else { console.log('error', error) }
   },
   updatePerson (personId, data) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const personData = { '2a0f1211cad87a393283f3167a72832c53ed7966': '' }
     _.forEach(data, (val, key) => {
       const pipedriveFiel = fieldsMap[key]
@@ -247,22 +270,37 @@ module.exports = {
     return personsApi.updatePerson(personId, newPersonData)
   },
   async searchDeal (term) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const { data: { items } } = await dealsApi.searchDeals(term)
     console.log('ITEMS SEARCHED: ', items)
     return items
   },
   async addDeal (dealData) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const newDealData = pipedrive.NewDeal.constructFromObject(dealData)
     const { success, data } = await dealsApi.addDeal(newDealData)
     console.log(' success: ', success, 'data: ', data)
     return { data, success }
   },
   updateDeal (dealId, data) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const newDealData = pipedrive.UpdateDealRequest.constructFromObject(data)
     return dealsApi.updateDeal(dealId, newDealData)
   },
   async signupCollectivite (data) {
-    console.log('-- SIGNUP COLLECTIVITE PIPEDRIVE --')
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     let { person } = await this.findPerson(data.email)
     if (!person) {
       console.log('Person not found, creating one')
@@ -277,6 +315,10 @@ module.exports = {
     }
   },
   async movePersonDealTo (email, from, to) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     const { person } = await this.findPerson(email)
     const personDeals = await this.getPersonDeals(person.id)
     // console.log('personDeals: ', personDeals)
@@ -285,6 +327,10 @@ module.exports = {
     if (dealIdToUpdate) { await this.updateDeal(dealIdToUpdate, { stage_id: to }) }
   },
   async signupStateAgent (userData) {
+    if (!process.env.PIPEDRIVE_API_KEY) {
+      console.log('The PIPEDRIVE_API_KEY environment variable is not defined.')
+      return
+    }
     try {
       console.log('-- SIGNUP STATE AGENT PIPEDRIVE --')
       const self = this

--- a/nuxt/server-middleware/modules/sendgrid.js
+++ b/nuxt/server-middleware/modules/sendgrid.js
@@ -1,5 +1,7 @@
 const sgMail = require('@sendgrid/mail')
+const preposition = process.env.NODE_ENV === 'development' ? '[Test] ' : ''
 sgMail.setApiKey(process.env.SENDGRID_API_KEY)
+
 
 module.exports = {
   sendEmail (message) {
@@ -13,6 +15,6 @@ module.exports = {
         email: 'contact@docurba.beta.gouv.fr',
         name: 'Equipe Docurba'
       }
-    }, message))
+    }, preposition + message))
   }
 }

--- a/nuxt/server-middleware/modules/sendgrid.js
+++ b/nuxt/server-middleware/modules/sendgrid.js
@@ -1,12 +1,12 @@
+const userEnvironment = require('./userEnvironment.js')
 const sgMail = require('@sendgrid/mail')
-const preposition = process.env.NODE_ENV === 'development' ? '[Test] ' : ''
 sgMail.setApiKey(process.env.SENDGRID_API_KEY)
 
 
 module.exports = {
   sendEmail (message) {
+    message.dynamic_template_data["subject_preposition"] = userEnvironment.messageProposition()
     return sgMail.send(Object.assign({
-      // from: 'fabien.ungerer@beta.gouv.fr' // This need to be a verified sender
       from: {
         email: 'equipe@docurba.beta.gouv.fr',
         name: 'L‘équipe docurba'
@@ -15,6 +15,6 @@ module.exports = {
         email: 'contact@docurba.beta.gouv.fr',
         name: 'Equipe Docurba'
       }
-    }, preposition + message))
+    }, message))
   }
 }

--- a/nuxt/server-middleware/modules/sendgrid.js
+++ b/nuxt/server-middleware/modules/sendgrid.js
@@ -5,6 +5,10 @@ sgMail.setApiKey(process.env.SENDGRID_API_KEY)
 
 module.exports = {
   sendEmail (message) {
+    if (!process.env.SENDGRID_API_KEY) {
+      console.log('The SENDGRID_API_KEY environment variable is not defined.')
+      return
+    }
     message.dynamic_template_data["subject_preposition"] = userEnvironment.messageProposition()
     return sgMail.send(Object.assign({
       from: {

--- a/nuxt/server-middleware/modules/sibApi.js
+++ b/nuxt/server-middleware/modules/sibApi.js
@@ -2,6 +2,10 @@ const SibApiV3Sdk = require('sib-api-v3-sdk')
 
 module.exports = {
   optinNewsLetter (email, optin, lists = []) {
+    if (!process.env.BREVO_API_KEY) {
+      console.log('The BREVO_API_KEY environment variable is not defined.')
+      return
+    }
     const defaultClient = SibApiV3Sdk.ApiClient.instance
     const apiKey = defaultClient.authentications['api-key']
     apiKey.apiKey = process.env.BREVO_API_KEY
@@ -14,8 +18,6 @@ module.exports = {
     createContact.attributes = { NEWUSER_OPTIN: optin }
 
     apiInstance.createContact(createContact).then(function (data) {
-      // eslint-disable-next-line no-console
-      console.log('API called successfully. Returned data: ' + JSON.stringify(data))
     }, function (error) {
       // eslint-disable-next-line no-console
       console.error('createContact error', error)

--- a/nuxt/server-middleware/modules/slack.js
+++ b/nuxt/server-middleware/modules/slack.js
@@ -1,13 +1,12 @@
-/* eslint-disable no-console */
+const userEnvironment = require('./userEnvironment.js')
 const axios = require('axios')
 const _ = require('lodash')
 const geo = require('./geo.js')
 const supabase = require('./supabase.js')
-const preposition = process.env.NODE_ENV === 'development' ? '[Test] ' : ''
+const preposition = userEnvironment.messageProposition() + ' '
 
 module.exports = {
   shareProcedure ({ from, to, type, procedure, pac }) {
-    console.log('from: ', from.poste)
     return axios({
       url: process.env.SLACK_WEBHOOK,
       method: 'post',
@@ -109,8 +108,6 @@ module.exports = {
     })
   },
   requestStateAgentAccess (userData) {
-    console.log('requestStateAgentAccess userData: ', userData)
-
     let textContent = ''
     if (userData.poste === 'ddt') {
       textContent = `- departement: ${userData.departement.nom_departement} - ${userData.departement.code_departement} \n - email: ${userData.email}`

--- a/nuxt/server-middleware/modules/slack.js
+++ b/nuxt/server-middleware/modules/slack.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
 const axios = require('axios')
+const _ = require('lodash')
 const geo = require('./geo.js')
 const supabase = require('./supabase.js')
-const _ = require('lodash')
+const preposition = process.env.NODE_ENV === 'development' ? '[Test] ' : ''
 
 module.exports = {
   shareProcedure ({ from, to, type, procedure, pac }) {
@@ -16,7 +17,7 @@ module.exports = {
             type: 'header',
             text: {
               type: 'plain_text',
-              text: `Partage d'${type === 'frp' ? 'une FRP' : 'un PaC'}: ${procedure.name}`
+              text: preposition + `Partage d'${type === 'frp' ? 'une FRP' : 'un PaC'}: ${procedure.name}`
             }
           },
           {
@@ -30,7 +31,7 @@ module.exports = {
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `Lien: ${process.env.APP_URL}${procedure.url}`
+              text: preposition + `Lien: ${process.env.APP_URL}${procedure.url}`
             }
           }
         ]
@@ -55,7 +56,7 @@ module.exports = {
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `https://docurba.beta.gouv.fr/collectivites/${userData.collectivite.code}/prescriptions`
+              text: preposition + `https://docurba.beta.gouv.fr/collectivites/${userData.collectivite.code}/prescriptions`
             }
           }
         ]
@@ -75,7 +76,7 @@ module.exports = {
             type: 'header',
             text: {
               type: 'plain_text',
-              text: `Demande d'accès Collectivité de ${userData.firstname} ${userData.lastname} ayant pour poste ${userData.poste}`
+              text: preposition + `Demande d'accès Collectivité de ${userData.firstname} ${userData.lastname} ayant pour poste ${userData.poste}`
             }
           },
           {
@@ -128,7 +129,7 @@ module.exports = {
             type: 'header',
             text: {
               type: 'plain_text',
-              text: `Demande d'accès ${userData.poste === 'dreal' ? 'DREAL' : 'DDT'} de ${userData.firstname} ${userData.lastname}`
+              text: preposition + `Demande d'accès ${userData.poste === 'dreal' ? 'DREAL' : 'DDT'} de ${userData.firstname} ${userData.lastname}`
             }
           },
           {
@@ -174,7 +175,7 @@ module.exports = {
             type: 'header',
             text: {
               type: 'plain_text',
-              text: `Demande de PAC de ${user_metadata.firstname} ${user_metadata.lastname}`
+              text: preposition + `Demande de PAC de ${user_metadata.firstname} ${user_metadata.lastname}`
             }
           },
           {
@@ -229,7 +230,7 @@ module.exports = {
           type: 'header',
           text: {
             type: 'plain_text',
-            text: `Nouvel event ${eventData.type}`
+            text: preposition + `Nouvel event ${eventData.type}`
           }
         },
         {

--- a/nuxt/server-middleware/modules/slack.js
+++ b/nuxt/server-middleware/modules/slack.js
@@ -7,6 +7,10 @@ const preposition = userEnvironment.messageProposition() + ' '
 
 module.exports = {
   shareProcedure ({ from, to, type, procedure, pac }) {
+    if (!process.env.SLACK_WEBHOOK )  {
+      console.log('The SLACK_WEBHOOK environment variable is not defined.')
+      return
+    }
     return axios({
       url: process.env.SLACK_WEBHOOK,
       method: 'post',
@@ -38,6 +42,10 @@ module.exports = {
     })
   },
   requestDepotActe (userData) {
+    if (!process.env.SLACK_WEBHOOK )  {
+      console.log('The SLACK_WEBHOOK environment variable is not defined.')
+      return
+    }
     return axios({
       url: process.env.SLACK_WEBHOOK,
       method: 'post',
@@ -63,6 +71,10 @@ module.exports = {
     })
   },
   requestCollectiviteAccess (userData) {
+    if (!process.env.SLACK_WEBHOOK )  {
+      console.log('The SLACK_WEBHOOK environment variable is not defined.')
+      return
+    }
     // See '/webhook/interactivity' to see fields needed by the webhook (action_id == 'collectivite_validation')
     const payload = _.pick(userData, ['user_id', 'email', 'firstname', 'lastname', 'collectivite_id'])
     return axios({
@@ -108,6 +120,10 @@ module.exports = {
     })
   },
   requestStateAgentAccess (userData) {
+    if (!process.env.SLACK_WEBHOOK )  {
+      console.log('The SLACK_WEBHOOK environment variable is not defined.')
+      return
+    }
     let textContent = ''
     if (userData.poste === 'ddt') {
       textContent = `- departement: ${userData.departement.nom_departement} - ${userData.departement.code_departement} \n - email: ${userData.email}`
@@ -159,6 +175,10 @@ module.exports = {
     })
   },
   requestPAC (userData, pacData) {
+    if (!process.env.SLACK_WEBHOOK )  {
+      console.log('The SLACK_WEBHOOK environment variable is not defined.')
+      return
+    }
     // eslint-disable-next-line camelcase
     const { user_metadata } = userData
 
@@ -201,6 +221,10 @@ module.exports = {
     userData,
     procedureData
   }) {
+    if (!process.env.SLACK_EVENT_CTBE) {
+      console.log('The SLACK_EVENT_CTBE environment variable is not defined.')
+      return
+    }
     const collectivitePorteuse = geo.getCollectivite(procedureData.collectivite_porteuse_id)
 
     const { data: procedures } = await supabase.from('procedures').select('*')

--- a/nuxt/server-middleware/modules/userEnvironment.js
+++ b/nuxt/server-middleware/modules/userEnvironment.js
@@ -1,0 +1,16 @@
+module.exports = {
+  authorizedEnvironments: {
+    development: 'développement',
+    review_app: 'recette jetable',
+    demo: 'démonstration',
+    production: 'production',
+  },
+  diplayName () {
+    return this.authorizedEnvironments[process.env.USER_ENVIRONMENT]
+  },
+  messageProposition() {
+    if (['development', 'review_app', 'demo'].includes(process.env.USER_ENVIRONMENT)) {
+      return `(Test en ${this.diplayName()})`
+    }
+  },
+}

--- a/nuxt/server-middleware/pdf.js
+++ b/nuxt/server-middleware/pdf.js
@@ -7,9 +7,7 @@ const axios = require('axios')
 const FormData = require('form-data')
 
 const gotenbergUrl = 'https://gotenberg-5hkjqo623a-od.a.run.app'
-// const gotenbergUrl = isDev ? 'http://localhost:8080' : 'https://gotenberg-5hkjqo623a-od.a.run.app'
 const printUrl = 'https://docurba.beta.gouv.fr'
-// const printUrl = isDev ? 'https://dev-dot-docurba.ew.r.appspot.com' : 'https://docurba.beta.gouv.fr'
 
 app.get('/:ref', (req, res) => {
   const { ref } = req.params

--- a/nuxt/server-middleware/pdf.js
+++ b/nuxt/server-middleware/pdf.js
@@ -6,8 +6,6 @@ app.use(express.json())
 const axios = require('axios')
 const FormData = require('form-data')
 
-// const isDev = process.env.NODE_ENV === 'development'
-
 const gotenbergUrl = 'https://gotenberg-5hkjqo623a-od.a.run.app'
 // const gotenbergUrl = isDev ? 'http://localhost:8080' : 'https://gotenberg-5hkjqo623a-od.a.run.app'
 const printUrl = 'https://docurba.beta.gouv.fr'


### PR DESCRIPTION
- [x] Distinguer les environnements : local, dev, démo et prod
- [x] Activer Slack : ajouter un préfixe à tous les messages avec le nom de l'environnement.
- [x] Activer Sendgrid : ajouter un préfixe à tous les messages avec le nom de l'environnement.
- [x] Ajout d'une variable dans tous les gabarits Sendgrid pour y intégrer le nom de l'environnement.
- [x] Nettoyage de isDev.
- [x] L'environnement de prod est l'environnement par défaut.
- [x] En recette et en démo, ajouter un bandeau statique en haut pour indiquer l'environnement.
- [x] Supprimer les variables en démo.

Ajout de la préposition correspondant à l'environnement.

Les recettes jetables et la démo tournent dans un environnement de production. On ne peut donc pas utiliser `isDev`. Ajouter le nom de l'environnement et le récupérer dans Nuxt me semble être la meilleure solution.

Cela nous permettra aussi d'afficher le nom de l'environnement dans un bandeau statique, comme évoqué par l'équipe précédemment. 

<img width="358" height="137" alt="env-banner" src="https://github.com/user-attachments/assets/49056ee6-ec56-4dc6-9a92-05c732f4dff8" />
