### PR TITLE
Import Sudocuh - Corrige le statut des procédures

### DIFF
--- a/nuxt/daily_dump/steps/sql/status_handler/4-trigger_event_procedure_status_handler.sql
+++ b/nuxt/daily_dump/steps/sql/status_handler/4-trigger_event_procedure_status_handler.sql
@@ -15,7 +15,7 @@ BEGIN
   WHERE id = event_processed.procedure_id;
 
   PERFORM set_procedure_status(procedure);
-  -- NUXT3_API_URL is hardcoded here because this dump will disappear soon and I don't know how to change it quickly in SQL.
+  /* NUXT3_API_URL is hardcoded here because this dump will disappear soon and I don't know how to change it quickly in SQL. */
   PERFORM net.http_get('https://nuxt3.docurba.incubateur.net/api/urba/procedures/' || event_processed.procedure_id || '/update');
   return event_processed;
 END;

--- a/nuxt/daily_dump/steps/sqlRunner.mjs
+++ b/nuxt/daily_dump/steps/sqlRunner.mjs
@@ -66,23 +66,19 @@ async function setAllStatus (config) {
     // 'rpc_events_by_procedures_ids.sql',
     // 'rpc_procedures_by_insee_codes.sql'
   ]
-  try {
-    const client = new Client(config)
-    await client.connect()
+  const client = new Client(config)
+  await client.connect()
 
-    console.log('Starting procedure status update.')
-    for (const sqlFilename of SQLS) {
-      console.log(`Processing ${sqlFilename}...`)
-      const sql = fs.readFileSync(`./daily_dump/steps/sql/status_handler/${sqlFilename}`)
-        .toString().replace(/(\r\n|\n|\r)/gm, ' ')
-        .replace(/\s+/g, ' ')
-      await client.query(sql)
-    }
-    await client.end()
-    console.log('Procedures status updated.')
-  } catch (error) {
-    console.log(error)
+  console.log('Starting procedure status update.')
+  for (const sqlFilename of SQLS) {
+    console.log(`Processing ${sqlFilename}...`)
+    const sql = fs.readFileSync(`./daily_dump/steps/sql/status_handler/${sqlFilename}`)
+      .toString().replace(/(\r\n|\n|\r)/gm, ' ')
+      .replace(/\s+/g, ' ')
+    await client.query(sql)
   }
+  await client.end()
+  console.log('Procedures status updated.')
 }
 
 async function createOriginalSchema (config) {


### PR DESCRIPTION
Ce fichier SQL est exécuté en enlevant tous les retours à la ligne. En utilisant la syntaxe `--`, le reste du fichier était ignoré, ce qui produit du SQL invalide. L'exécution de ce fichier n'était pas importante pour l'import, mais l'exception levée empêchait l'exécution du fichier suivant (`5-run_status.sql`) qui détermine le statut des procédures.

On évite ce souci en utilisant un commentaire de bloc.

On enlève aussi le try/catch presque silencieux qui nous a empêché de constater le problème depuis un mois (https://github.com/MTES-MCT/Docurba/commit/bdde0dc59bac4c38724bd32f46c8c101d109dabc).

ref https://github.com/MTES-MCT/Docurba/issues/1466
ref https://github.com/MTES-MCT/Docurba/issues/1486

---

Review plus facile en cochant "Hide whitespace".