### PR TITLE
Version minimale des recettes jetables

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -45,4 +45,3 @@ jobs:
       - run: ruff format --diff .
       - run: ruff check --output-format=github .
       - run: python -m django makemigrations --check --dry-run --noinput || (echo "⚠ Migration manquante ⚠"; exit 1)
-

--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -1,0 +1,192 @@
+name: 🕵 Création d'une recette jetable
+
+# L'action est lancée lorsque l'étiquette « recette-jetable » est ajoutée à la PR.
+on:
+  pull_request:
+    types: [ labeled ]
+  # https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.TEST_SUPABASE_ACCESS_TOKEN }}
+  SUPABASE_PROJECT_ID: ${{ secrets.TEST_SUPABASE_PROJECT_ID }}
+  BRANCH: ${{ github.head_ref }}
+  PR_ID: ${{ github.event.number }}
+  SCALINGO_DJANGO_APP_NAME: docurba-django-demo
+  SCALINGO_NUXT_APP_NAME: docurba-nuxt-demo
+  NUXT3_REPO_HTTPS: https://github.com/betagouv/docurba-nuxt3/
+  NUXT3_BRANCH: main
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.event.action == 'labeled' && github.event.label.name == 'recette-jetable'
+
+    steps:
+    - name: 📥 Récupération du code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.0
+      with:
+        ref: ${{ env.BRANCH }}
+
+    - name: 🏷️ Définition des noms de la recette jetable
+      run: |
+        # Le nom est déterminé automatiquement par Scalingo pour les applications Nuxt2 et Django
+        # car ce sont des recettes jetables.
+        # Suivons le même modèle pour Supabase et Nuxt3.
+        echo "SUPABASE_REVIEW_APP_NAME=supabase-pr${PR_ID}" >> $GITHUB_ENV
+        echo "NUXT_3_REVIEW_APP_NAME=docurba-nuxt3-pr${PR_ID}" >> $GITHUB_ENV
+        echo "NUXT_2_REVIEW_APP_NAME=${SCALINGO_NUXT_APP_NAME}-pr${PR_ID}" >> $GITHUB_ENV
+        echo "DJANGO_REVIEW_APP_NAME=${SCALINGO_DJANGO_APP_NAME}-pr${PR_ID}" >> $GITHUB_ENV
+
+    # La version est figée car la dernière version casse lors de l'envoi de la configuration.
+    # L'erreur est cryptique.
+    - name: 🛠️ Installation de la CLI Supabase
+      uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51
+      with:
+        version: 2.60.0
+
+    - name: 🪆 Creation de la branche Supabase
+      run: |
+       supabase branches --project-ref ${SUPABASE_PROJECT_ID} create ${SUPABASE_REVIEW_APP_NAME}
+
+    - name: 🤹‍♀️ Export des variables d'environment à partir de Supabase
+      shell: bash
+      run: |
+        until supabase branches --project-ref ${SUPABASE_PROJECT_ID} get ${SUPABASE_REVIEW_APP_NAME} -o env | grep --quiet "SUPABASE_URL" &> /dev/null
+        do
+          echo "Attendons que la base Supabase soit prête pendant encore 20 secondes."
+          sleep 20
+        done
+
+        env_vars=$(supabase branches --project-ref ${SUPABASE_PROJECT_ID} get ${SUPABASE_REVIEW_APP_NAME} -o env)
+        declare -A env_dict
+        env_dict["DATABASE_URL"]=$(echo "${env_vars}" | grep -w "POSTGRES_URL" | sed -r 's/POSTGRES_URL=//g' | sed -r 's/\"//g')
+        env_dict["SUPABASE_ANON_KEY"]=$(echo "${env_vars}" | grep -w "SUPABASE_ANON_KEY" | sed -r 's/SUPABASE_ANON_KEY=//g' | sed -r 's/\"//g')
+        env_dict["SUPABASE_ADMIN_KEY"]=$(echo "${env_vars}" | grep -w "SUPABASE_SERVICE_ROLE_KEY" | sed -r 's/SUPABASE_SERVICE_ROLE_KEY=//g' | sed -r 's/\"//g')
+        env_dict["SUPABASE_URL"]=$(echo "${env_vars}" | grep -w "SUPABASE_URL" | sed -r 's/SUPABASE_URL=//g' | sed -r 's/\"//g')
+
+        # https://www.chunyangwen.com/blog/shell/bash-array-dict.html
+        for key in "${!env_dict[@]}"
+        do
+          value=${env_dict[${key}]};
+          # https://docs.github.com/fr/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log
+          echo "::add-mask::${value}";
+          echo "${key}=${value}" >> $GITHUB_ENV
+        done
+
+    # La configuration de chaque nouvelle branche reprend celle par défaut et non celle du projet parent.
+    # Le fichier supabase/config.toml est le seul moyen documenté par Supabase
+    # pour mettre à jour la configuration d'un projet.
+    # https://github.com/orgs/supabase/discussions/3765
+    # https://supabase.com/docs/reference/cli/supabase-config-push
+    - name: 🤹‍♀️ Mise à jour de la configuration de Supabase
+      continue-on-error: true
+      run: |
+        supabase_branch_id=$(echo "${SUPABASE_URL}" | sed --expression 's/\(https:\/\/\|\.supabase\.co\)//g')
+        supabase --project-ref "${supabase_branch_id}" --yes config push
+
+    - name: 🛠️ Installation de la CLI Scalingo
+      uses: scalingo-community/setup-scalingo@87fe86eedc708ffb9d232c756b21f6a5784f6c8a # v0.1.1
+      with:
+        #  Jeton personnel de Céline Martinet Sanchez.
+        api_token: ${{ secrets.SCALINGO_API_TOKEN }}
+        region: 'osc-fr1'
+
+    - name: 🪆 Création de l'application Nuxt 3
+      run: |
+        # Il n'est pas possible de créer une recette jetable pour Nuxt3 car chaque recette jetable
+        # s'appuie sur une branche Git différente de celle utilisée pour le dépôt parent.
+        scalingo create "${NUXT_3_REVIEW_APP_NAME}"
+        app_url="https://${NUXT_3_REVIEW_APP_NAME}.osc-fr1.scalingo.io"
+        scalingo --app ${NUXT_3_REVIEW_APP_NAME} env-set \
+         SUPABASE_URL="${SUPABASE_URL}" \
+         SUPABASE_ADMIN_KEY="${SUPABASE_ADMIN_KEY}"\
+         NODE_OPTIONS="--max-old-space-size=4096"
+        scalingo --app "${NUXT_3_REVIEW_APP_NAME}" integration-link-create --branch "${NUXT3_BRANCH}" "${NUXT3_REPO_HTTPS}"
+        scalingo --app "${NUXT_3_REVIEW_APP_NAME}" integration-link-manual-deploy main
+        echo "NUXT3_URL=${app_url}" >> $GITHUB_ENV
+        echo "Utilisation de la branche ${NUXT3_BRANCH}."
+        echo "Pour déployer une autre branche, vous pouvez modifier ce script ou utiliser l'interface graphique."
+
+    - name: 🪆 Création et déploiement de la recette jetable Nuxt2
+      run: |
+        # Le nom est créé par Scalingo.
+        # Création d'une recette jetable.
+        scalingo --app ${SCALINGO_NUXT_APP_NAME} integration-link-manual-review-app ${{ github.event.number }}
+        # Mise à jour de la configuration.
+        scalingo --app "${NUXT_2_REVIEW_APP_NAME}" env-set \
+         SUPABASE_URL="${SUPABASE_URL}" \
+         SUPABASE_ADMIN_KEY="${SUPABASE_ADMIN_KEY}" \
+         SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY}"\
+         NUXT3_API_URL="${NUXT3_URL}"
+        scalingo --app "${NUXT_2_REVIEW_APP_NAME}" integration-link-update --auto-deploy --branch "${BRANCH}" --destroy-on-close
+
+    - name: 🪆 Déploiement de la recette jetable Nuxt2
+      run: |
+        # Déploiement manuel.
+        scalingo --app "${NUXT_2_REVIEW_APP_NAME}" integration-link-manual-deploy "${BRANCH}"  &> /dev/null
+        # Récupération de NUXT_URL pour Django.
+        until scalingo apps | grep "${NUXT_2_REVIEW_APP_NAME}" | grep --quiet 'running' &> /dev/null
+        do
+          echo "En attente de l'application Nuxt."
+          sleep 1m
+        done
+        nuxt_url=$(scalingo --app "${NUXT_2_REVIEW_APP_NAME}" env-get NUXT_URL)
+        echo "NUXT_URL=${nuxt_url}" >> $GITHUB_ENV
+
+    - name: 🛠️ Installation de Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: django/.python-version
+
+    - name: 🪆 Création de la recette jetable Django
+      run: |
+        # La longueur de la clé secrète doit être supérieure à 50 caractères,
+        # or le générateur de secret de Scalingo génère une clé de 32 caractères.
+        # Selon le support, il n'est pas possible d'en spécifier la longueur dans scalingo.json.
+        django_secret_key=$(python -c "import secrets; print(secrets.token_hex(60))")
+        echo "::add-mask::${django_secret_key}";
+        scalingo --app ${SCALINGO_DJANGO_APP_NAME} integration-link-manual-review-app ${{ github.event.number }}
+        scalingo --app "${DJANGO_REVIEW_APP_NAME}" env-set \
+         UPSTREAM_NUXT="${NUXT_URL}" \
+         DATABASE_URL="${DATABASE_URL}" \
+         NUXT3_API_URL="${NUXT3_URL}" \
+         SECRET_KEY="${django_secret_key}"
+        scalingo --app "${DJANGO_REVIEW_APP_NAME}" integration-link-update --auto-deploy --branch "${BRANCH}" --destroy-on-close
+
+    - name: 🪆 Déploiement de la recette jetable Django
+      run: |
+        scalingo --app "${DJANGO_REVIEW_APP_NAME}" integration-link-manual-deploy "${BRANCH}" &> /dev/null
+        until scalingo apps | grep "${DJANGO_REVIEW_APP_NAME}" | grep --quiet 'running' &> /dev/null
+        do
+          echo "En attente de l'application Django pendant 1 minute."
+          sleep 1m
+        done
+        django_url=$(scalingo --app "${DJANGO_REVIEW_APP_NAME}" env-get APP_URL)
+        echo "DJANGO_URL=${django_url}" >> $GITHUB_ENV
+
+    - name: 🤹‍♀️ Intégration de l'URL de Django dans Nuxt2
+      run: scalingo --app "${NUXT_2_REVIEW_APP_NAME}" env-set APP_URL="${DJANGO_URL}"
+
+    - name: 🍻 Ajout du lien en commentaire de la PR
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        message: |-
+          🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](${{ env.DJANGO_URL }})
+          Lien vers Nuxt3 pour modifier le déclencheur : [${{ env.NUXT3_URL }}](${{ env.NUXT3_URL }}).
+          Attention, les données ne sont pas encore importées. Revenez quand l'action GitHub sera terminée.
+
+    - name: 🔂 Génération des données
+      run: scalingo --app "${DJANGO_REVIEW_APP_NAME}" run './scripts/restore_database.sh ${DATABASE_URL}' &> /dev/null
+
+    - name: ⏩ Lancement des migrations
+      run: |
+        # La connexion PG doit être libérée avant de pouvoir passer les migrations
+        # mais on ne sait jamais combien de temps Supabase met à le faire.
+        sleep 5m
+        scalingo --app "${DJANGO_REVIEW_APP_NAME}" run 'django-admin migrate'

--- a/.github/workflows/review_app_removal.yml
+++ b/.github/workflows/review_app_removal.yml
@@ -1,0 +1,47 @@
+name: 🔪 Suppression d'une recette jetable
+
+# L'action est lancée lorsqu'une PR étiquetée « recette-jetable » est fermée.
+# Les applications Nuxt2 et Django sont supprimées automatiquement par Scalingo
+# lorque la PR est fermée ou fusionnée car il s'agit de recettes jetables.
+# https://doc.scalingo.com/platform/app/review-apps
+on:
+  pull_request:
+    types: [ closed ]
+
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.TEST_SUPABASE_ACCESS_TOKEN }}
+  SUPABASE_PROJECT_ID: ${{ secrets.TEST_SUPABASE_PROJECT_ID }}
+  BRANCH: ${{ github.head_ref }}
+  PR_ID: ${{ github.event.number }}
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    if: contains( github.event.pull_request.labels.*.name, 'recette-jetable')
+
+    steps:
+    - name: 🏷️ Définition des noms de la recette jetable
+      run: |
+        # Le nom est déterminé automatiquement par Scalingo pour les applications Nuxt2 et Django
+        # car ce sont des recettes jetables.
+        # Suivons le même modèle pour Supabase et Nuxt3.
+        echo "SUPABASE_REVIEW_APP_NAME=supabase-pr${PR_ID}" >> $GITHUB_ENV
+        echo "NUXT_3_REVIEW_APP_NAME=docurba-nuxt3-pr${PR_ID}" >> $GITHUB_ENV
+
+    - name: 🛠️ Installation de la CLI de Scalingo
+      uses: scalingo-community/setup-scalingo@87fe86eedc708ffb9d232c756b21f6a5784f6c8a # v0.1.1
+      with:
+        api_token: ${{ secrets.SCALINGO_API_TOKEN }}
+        region: 'osc-fr1'
+
+    - name: 🚮 Suppression de l'application Nuxt3
+      run: scalingo destroy --app "${NUXT_3_REVIEW_APP_NAME}" --force
+
+
+    - name: 🛠️ Installation de la CLI de Supabase
+      uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51
+      with:
+        version: latest
+
+    - name: 🚮 Suppression de la branche Supabase
+      run: supabase branches --project-ref "${SUPABASE_PROJECT_ID}" delete "${SUPABASE_REVIEW_APP_NAME}"

--- a/django/.env.example
+++ b/django/.env.example
@@ -20,3 +20,7 @@ export RCLONE_CONFIG_OUTSCALE_ENDPOINT=""
 export RCLONE_CRYPT_PASSWORD=""
 export RCLONE_CRYPT_PASSWORD2=""
 export RCLONE_CONFIG="path_to_rclone_config_file"
+
+# Review apps
+export SUPABASE_PROJECT_ID=""
+export SUPABASE_ACCESS_TOKEN=""

--- a/django/scalingo.json
+++ b/django/scalingo.json
@@ -1,7 +1,23 @@
 {
     "env": {
-        "ALLOWED_HOSTS": {
+        "APP_URL": {
+            "description": "URL of the application",
             "generator": "url"
+        },
+        "ALLOWED_HOSTS": {
+            "description": "Add app URL to Django's allowed hosts",
+            "generator": "template",
+            "template": "%APP%.osc-fr1.scalingo.io"
+        },
+        "BACKUPS_SUPABASE_MODIFY_TRIGGERS": {
+            "description": "Update PG triggers at the end of the restoration script",
+            "value": "True"
+        }
+    },
+    "formation": {
+        "web": {
+            "amount": 1,
+            "size": "S"
         }
     }
 }

--- a/django/scripts/activate_extensions.sql
+++ b/django/scripts/activate_extensions.sql
@@ -1,0 +1,5 @@
+create extension if not exists moddatetime schema extensions;
+create extension if not exists pg_net schema extensions;
+
+-- https://supabase.com/docs/guides/troubleshooting/refresh-postgrest-schema
+notify pgrst, 'reload schema';

--- a/django/scripts/drop_update_triggers.sql
+++ b/django/scripts/drop_update_triggers.sql
@@ -1,9 +1,8 @@
--- Mise à jour de la colonne `updated_at` lors de chaque modification.
-create extension if not exists moddatetime schema extensions;
-DROP TRIGGER IF EXISTS "handle_updated_at" ON public.doc_frise_events;
-create trigger handle_updated_at before update on public.doc_frise_events
-  for each row execute procedure moddatetime (updated_at);
-
 -- Pipedrive n'est pas configuré dans les recettes jetables.
-DROP TRIGGER IF EXISTS "Pipedrive Sharing Update" ON public.projects_sharing;
-DROP TRIGGER IF EXISTS "Pipedrive Update" ON public.profiles;
+drop trigger if exists "Pipedrive Sharing Update" on public.projects_sharing;
+drop trigger if exists "Pipedrive Update" on public.profiles;
+
+-- Mise à jour de la colonne `updated_at` lors de chaque modification.
+drop trigger if exists "handle_updated_at" on public.doc_frise_events;
+create trigger handle_updated_at before update on public.doc_frise_events
+  for each row execute procedure extensions.moddatetime (updated_at);

--- a/django/scripts/grant_usage_and_privileges.sql
+++ b/django/scripts/grant_usage_and_privileges.sql
@@ -13,3 +13,6 @@ alter default privileges in schema public grant all on sequences to postgres, an
 
 alter role anon set statement_timeout = '3s';
 alter role authenticated set statement_timeout = '8s';
+
+-- https://supabase.com/docs/guides/troubleshooting/refresh-postgrest-schema
+notify pgrst, 'reload schema';

--- a/django/scripts/restore_database.sh
+++ b/django/scripts/restore_database.sh
@@ -84,11 +84,6 @@ psql \
   --file ${backup_file} \
   --dbname ${database_restoration_url}
 
-# https://supabase.com/docs/guides/troubleshooting/refresh-postgrest-schema
-psql \
-  --command "NOTIFY pgrst, 'reload schema';"\
-  --dbname ${database_restoration_url}
-
 if [[ ${BACKUPS_SUPABASE_GRANT_PRIVILEGES_TO_USERS} == "True" ]]; then
   echo "Définition des droits d'accès."
   psql \
@@ -97,12 +92,20 @@ if [[ ${BACKUPS_SUPABASE_GRANT_PRIVILEGES_TO_USERS} == "True" ]]; then
 fi
 
 if [[ ${BACKUPS_SUPABASE_MODIFY_TRIGGERS} == "True" ]]; then
-  echo "Suppression et modification des déclencheurs."
+  echo "Activation des extensions"
+  psql --dbname ${database_restoration_url} --file ${script_folder_path}/activate_extensions.sql
+
   if [[ ! -n ${NUXT3_API_URL} ]]; then
     echo "Impossible de modifier les déclencheurs car la variable NUXT3_API_URL n'est pas définie."
   fi
+  echo "Suppression et modification des déclencheurs."
   psql --dbname ${database_restoration_url} --file ${script_folder_path}/drop_update_triggers.sql
 fi
+
+# https://supabase.com/docs/guides/troubleshooting/refresh-postgrest-schema
+psql \
+  --command "NOTIFY pgrst, 'reload schema';"\
+  --dbname ${database_restoration_url}
 
 echo "La restauration est terminée !"
 

--- a/nuxt/.env.example
+++ b/nuxt/.env.example
@@ -1,10 +1,11 @@
 export SUPABASE_ADMIN_KEY="<service role> legacy API Key"
 export SUPABASE_ANON_KEY="<anon public> legacy API key"
 export SUPABASE_URL="https://{project_id}.supabase.co"
-# Its value is automatically generated in the review app environement. See scalingo.json.
-# https://doc.scalingo.com/platform/app/review-apps#configuration-of-review-apps
-# Also, it could be replaced by `req.protocol + '://' + req.host` directly.
-export APP_URL="https://nuxtserver.domain.com" # without the trailing slash
+# APP_URL is used in emails and Slack webhooks to provide the full path to our app, including the domain name.
+# As Django acts as a proxy to our app, APP_URL points to its address.
+export APP_URL="https://djangoserver.domain.com" # without the trailing slash
+# Only used in review apps to provide Nuxt's domain name to Django.
+export NUXT_URL="https://nuxtserver.domain.com"
 export NUXT3_API_URL="https://nuxt3server.domain.com" # without the trailing slash
 
 # Not mandatory environment variables.

--- a/nuxt/scalingo.json
+++ b/nuxt/scalingo.json
@@ -1,7 +1,15 @@
 {
+  "name": "Nuxt review apps",
   "env": {
-    "APP_URL": {
+    "NUXT_URL": {
+      "description": "URL of the application",
       "generator": "url"
     }
-  }
+  },
+    "formation": {
+        "web": {
+            "amount": 1,
+            "size": "M"
+        }
+    }
 }


### PR DESCRIPTION

:warning: Après la création des recettes, il faut vérifier que les déclencheurs PG ont bien été modifiés. Si ce n'est pas le cas :

```
$ scalingo run --app django-review-app-name 'psql --dbname ${DATABASE_URL} --file $HOME/scripts/drop_update_triggers.sql'
```

----

Il faut encore lancer la modification du déclencheur qui fait un GET à la main. Voir le ticket #1630 

Il existe plusieurs manières de le faire mais voici celle qui me semble la plus rapide aujourd'hui :
- récupérer l'URL de Nuxt3 dans l'application Scalingo
- aller dans la console Supabase
- lancer la commande suivante (en remplaçant `NUXT3_API_URL`) : 

```
CREATE OR REPLACE FUNCTION event_procedure_status_handler()
RETURNS trigger AS $$
declare
  procedure procedures;
  event_processed doc_frise_events;
BEGIN
  IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' then
    event_processed := new;
  else
    event_processed := old;
  END IF;

  SELECT * into procedure
  FROM procedures
  WHERE id = event_processed.procedure_id;

  PERFORM set_procedure_status(procedure);
  PERFORM net.http_get('${NUXT3_API_URL}' || '/api/urba/procedures/' || event_processed.procedure_id || '/update');
  return event_processed;
END;
$$ LANGUAGE plpgsql;

-- Il semble pas être utilisé mais modifions-le au cas où.
CREATE OR REPLACE FUNCTION procedure_status_handler()
RETURNS trigger AS $$
declare
  procedure procedures;
BEGIN
  IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' then
    procedure := new;
  else
    procedure := old;
  END IF;

  PERFORM set_procedure_status(procedure);
  PERFORM http_get('${NUXT3_API_URL}' || '/api/urba/procedures/' || procedure.id || '/update');
  return procedure;
END;
$$ LANGUAGE plpgsql;
```

À faire après la validation :
- [x] Fusionner tous les commits en un

# Notes

Suite [#recettes](https://github.com/MTES-MCT/Docurba/pull/1629) fermée par mégarde : j'ai clos la PR pour supprimer les applications Nuxt2 et Django puis fait un force push, il est donc impossible de la rouvrir.

- Restaurer les données et lancer les migrations après l'ajout du lien

L'application reste utilisable sans les données. Scalingo coupe le script qui restaure les données parfois de manière
inexpliquée. C'est dommage d'avoir à tout relancer alors que seules les deux dernières étapes ont échoué et que l'application reste utilisable.
Ajoutons donc le lien vers la recette quand même, mais laissons l'action GH échouer afin de pouvoir relancer les deux dernières étapes manuellement.

- Lancer les migrations après la restauration des données

Le script `post_deploy` exécute les migrations quand l'application est déployée, c'est-à-dire avant d'avoir restauré les données.
Une solution aurait pu être d'ajouter l'entrée `first_deploy` à `scalingo.json` mais Scalingo coupe parfois le script sans raison valable (voir point ci-dessus).
