### PR TITLE
Doc API - Précise que `avant` est inclusif

### DIFF
--- a/nuxt/content/Dev/API/communes.md
+++ b/nuxt/content/Dev/API/communes.md
@@ -22,7 +22,7 @@ Cet endpoint retourne les données par communes avec des informations sur l'inte
 #### Paramètres de requête disponibles
 
 - `departement` : Filtrer par le code INSEE du département.
-- `avant` : Ne prend en compte que les événements avant ce jour, au format `YYYY-MM-DD`.
+- `avant` : Ne prend en compte que les événements jusqu'à ce jour, au format `YYYY-MM-DD`.
 
 ### Réponse
 

--- a/nuxt/content/Dev/API/perimetres.md
+++ b/nuxt/content/Dev/API/perimetres.md
@@ -22,7 +22,7 @@ Retourne les procédures de chaque commune et leur opposabilité.
 #### Paramètres de requête disponibles
 
 - `departement` : Filtrer par le code INSEE du département.
-- `avant` : Ne prend en compte que les événements avant ce jour, au format `YYYY-MM-DD`.
+- `avant` : Ne prend en compte que les événements jusqu'à ce jour, au format `YYYY-MM-DD`.
 
 ### Réponse
 

--- a/nuxt/content/Dev/API/scots.md
+++ b/nuxt/content/Dev/API/scots.md
@@ -27,7 +27,7 @@ Ici la préposition `scot_` fait en faire référence à la collectivité porteu
 #### Paramètres de requête disponibles
 
 - `departement` : Filtrer par le code INSEE du département.
-- `avant` : Ne prend en compte que les événements avant ce jour, au format `YYYY-MM-DD`.
+- `avant` : Ne prend en compte que les événements jusqu'à ce jour, au format `YYYY-MM-DD`.
 
 ### Réponse
 


### PR DESCRIPTION
Le comportement avait changé dans https://github.com/MTES-MCT/Docurba/commit/f305765fb58784409da1a1b8004c8a825443b2d4