### PR TITLE
Appelle des URLs plus courtes pour les infos des collectivités

### DIFF
--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -286,17 +286,14 @@ export default {
         console.log('error getProcedures', error)
       }
 
-      const collectiviteCodes = procedures.map(p => p.collectivite_porteuse_id)
-
-      procedures.forEach((p) => {
-        collectiviteCodes.push(...p.procedures_perimetres.map(c => c.collectivite_code))
-      })
+      const collectiviteCodes = new Set(procedures.flatMap(p => [
+        p.collectivite_porteuse_id,
+        ...p.procedures_perimetres.map(c => c.collectivite_code)
+      ]))
 
       const { data: collectivites } = await axios({
         url: '/api/geo/collectivites',
-        params: {
-          codes: collectiviteCodes
-        }
+        params: new URLSearchParams(collectiviteCodes.map(code => ['codes', code]))
       })
 
       const enrichedProcedures = procedures.map((p) => {

--- a/nuxt/plugins/urbanisator.js
+++ b/nuxt/plugins/urbanisator.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { groupBy, uniqBy, uniq, orderBy, maxBy } from 'lodash'
+import { groupBy, uniqBy, orderBy, maxBy } from 'lodash'
 import axios from 'axios'
 
 export default ({ $supabase, $dayjs }, inject) => {
@@ -60,14 +60,14 @@ export default ({ $supabase, $dayjs }, inject) => {
       return procedures
     },
     async getProceduresPerimetre (procedures, collectiviteId) {
-      const collectivitesCodes = [collectiviteId]
-      procedures.forEach((p) => {
-        collectivitesCodes.push(...p.procedures_perimetres.map(c => c.collectivite_code))
-      })
+      const collectivitesCodes = new Set(procedures.flatMap(p =>
+        p.procedures_perimetres.map(c => c.collectivite_code)
+      ))
+      collectivitesCodes.add(collectiviteId)
 
       const { data: collectivites } = await axios({
         url: '/api/geo/collectivites',
-        params: { codes: uniq(collectivitesCodes) }
+        params: new URLSearchParams(collectivitesCodes.map(code => ['codes', code]))
       })
 
       procedures.forEach((procedure) => {


### PR DESCRIPTION
- Par défaut, `axios({params: {foo : [1,2]}})` produit des query string de la forme `?foo[]=1&foo[]=2`. En utilisant `URLSearchParams()`, on produit des URLs sans les `[]`, de la forme `?foo=1&foo=2`. Comme le serveur Nuxt appelé interprète les deux formats de manière identique, l'API retourne les mêmes informations. Ces URLs raccourcies permettent de consulter la page du Pôle Métropolitain du Grand Amiénois (200082063).
- Sur la page de création de procédure secondaire, on ne dédoublonnait pas les codes INSEE des collectivités avant de générer l'URL. C'est maintenant le cas.
- Le dédoublonnement passe de `lodash.uniq` a un `Set` natif.

ref https://github.com/MTES-MCT/Docurba/issues/1090
ref https://github.com/MTES-MCT/Docurba/issues/1237