### PR TITLE
Nuxt : afficher « (PPA) » après le poste

### DIFF
--- a/nuxt/components/Frise/ShareDialog.vue
+++ b/nuxt/components/Frise/ShareDialog.vue
@@ -46,7 +46,7 @@
                         {{ item.label }}
                       </v-list-item-title>
                       <v-list-item-subtitle>
-                        {{ $utils.formatPostes(item) }}
+                        {{ $utils.formatPostesAndSide(item) }}
                       </v-list-item-subtitle>
                     </v-list-item-content>
                   </v-list-item>
@@ -89,7 +89,7 @@
                           {{ collaborator.label }}
                         </v-list-item-title>
                         <v-list-item-subtitle>
-                          {{ $utils.formatPostes(collaborator) }}
+                          {{ $utils.formatPostesAndSide(collaborator) }}
                         </v-list-item-subtitle>
                       </v-list-item-content>
                       <v-list-item-action>

--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -183,7 +183,7 @@
                           <div>
                             {{ collaborator.label }}
                             <div class="mention-grey--text">
-                              {{ $utils.formatPostes(collaborator) }}
+                              {{ $utils.formatPostesAndSide(collaborator) }}
                             </div>
                           </div>
                         </li>

--- a/nuxt/pages/frise/_procedureId/invite.vue
+++ b/nuxt/pages/frise/_procedureId/invite.vue
@@ -34,7 +34,7 @@
                                 {{ collaborator.label }}
                               </v-list-item-title>
                               <v-list-item-subtitle>
-                                {{ $utils.formatPostes(collaborator) }}
+                                {{ $utils.formatPostesAndSide(collaborator) }}
                               </v-list-item-subtitle>
                             </v-list-item-content>
                             <v-list-item-action>

--- a/nuxt/plugins/utils.js
+++ b/nuxt/plugins/utils.js
@@ -78,7 +78,7 @@ export default ({ app }, inject) => {
     POSTES_PPA: {
       region: 'Région'
     },
-    formatPostes (profile) {
+    formatPostesAndSide (profile) {
       let postes = []
 
       const POSTES = { ...this.POSTES_ETAT, ...this.POSTES_COLLECTIVITE, ...this.POSTES_PPA }


### PR DESCRIPTION
<img width="304" height="320" alt="image" src="https://github.com/user-attachments/assets/201005b1-498f-4aa1-9074-45b21878443b" />
