### PR TITLE
Nuxt : afficher le lien vers la section PAC si l'utilisateur a les droits

### DIFF
--- a/nuxt/components/Dashboard/DUProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUProcedureItem.vue
@@ -59,6 +59,7 @@
           </span>
         </nuxt-link>
         <nuxt-link
+          v-if="$user.canViewSectionPAC()"
           class="primary--text text-decoration-underline mr-4"
           :to="`/ddt/${$route.params.departement}/pac?search=${$route.params.collectiviteId}`"
         >


### PR DESCRIPTION
Correction d'un bug.
Ref https://github.com/MTES-MCT/Docurba/issues/1728
