### PR TITLE
Django : correction d'erreurs 500 sur l'admin et sur la page de debug `collectivite`

### DIFF
--- a/django/core/admin.py
+++ b/django/core/admin.py
@@ -64,6 +64,7 @@ class ProcedureAdmin(admin.ModelAdmin):
         "django_status",
         "collectivite_porteuse",
         "commentaire",
+        "current_perimetre",
         "is_principale",
     ]
 

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -355,10 +355,8 @@ class Procedure(models.Model):
         output_field=models.BooleanField(),
         db_persist=True,
     )
-    # Enabling these two columns led to a big performance trouble on our API.
-    # See the commit message.
-    # initial_perimetre = models.JSONField(null=True)  # noqa: ERA001
-    # current_perimetre = models.JSONField(null=True)  # noqa: ERA001
+    initial_perimetre = models.JSONField(null=True)
+    current_perimetre = models.JSONField(null=True)
 
     # Denormalized information used only by Nuxt. See self.statut for the Django logic.
     status = models.CharField(choices=ProcedureStatusChoices, blank=True, null=True)  # noqa: DJ001
@@ -602,7 +600,8 @@ class CollectiviteQuerySet(models.QuerySet):
             .prefetch_related(
                 models.Prefetch(
                     "procedure_set",
-                    Procedure.objects.with_events(avant=avant)
+                    Procedure.objects.defer("current_perimetre", "initial_perimetre")
+                    .with_events(avant=avant)
                     .without_adhesions_count()
                     .filter(
                         doc_type="SCOT",
@@ -695,8 +694,10 @@ class CommuneQuerySet(models.QuerySet):
     def with_procedures_principales(
         self, *, avant: date | None = None, with_adhesions_count: bool = True
     ) -> Self:
-        procedures_principales = Procedure.objects.with_events(avant=avant).filter(
-            parente=None, archived=False
+        procedures_principales = (
+            Procedure.objects.defer("current_perimetre", "initial_perimetre")
+            .with_events(avant=avant)
+            .filter(parente=None, archived=False)
         )
         if not with_adhesions_count:
             procedures_principales = procedures_principales.without_adhesions_count()
@@ -716,9 +717,9 @@ class CommuneQuerySet(models.QuerySet):
         return self.prefetch_related(
             models.Prefetch(
                 "procedures",
-                Procedure.objects.with_events(avant=avant).filter(
-                    doc_type="SCOT", parente=None, archived=False
-                ),
+                Procedure.objects.defer("current_perimetre", "initial_perimetre")
+                .with_events(avant=avant)
+                .filter(doc_type="SCOT", parente=None, archived=False),
                 to_attr="procedures_principales",
             )
         )

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -27,9 +27,9 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
             "Le paramètre 'avant' doit être une date valide au format YYYY-MM-DD."
         )
 
-    communes = Commune.objects.with_procedures_principales(
-        avant=avant, with_adhesions_count=False
-    )
+    communes = Commune.objects.only(
+        "id", "type", "departement"
+    ).with_procedures_principales(avant=avant, with_adhesions_count=False)
     if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 


### PR DESCRIPTION
- Django admin : le champ `Collectivite.code_insee` n'existait pas et causait une 500.
- Page de débug `collectivite` : affichage d'une erreur 404 si les collectivités ne sont pas trouvées (au lieu d'une 500).
- Modèle `Procedure` : réactivation des champs `current_perimetre` et `initial_perimetre` qui avaient dû être désactivés. Utilisation de `defer` pour éviter les problèmes de performance dans les API exposées en attendant de revoir leur mécanisme. 