### PR TITLE
Admin - Améliorations pour les Profils

### DIFF
--- a/django/core/admin.py
+++ b/django/core/admin.py
@@ -8,15 +8,13 @@ from core.models import Collectivite, Commune, Procedure
 @admin.register(Collectivite)
 class CollectiviteAdmin(admin.ModelAdmin):
     list_display = (
-        "code_insee",
         "__str__",
         "type",
         "competence_plan",
         "competence_schema",
     )
-    list_display_links = ("code_insee", "__str__")
     list_filter = ("type", "competence_plan", "competence_schema", "departement")
-    search_fields = ("nom", "code_insee")
+    search_fields = ("nom", "code_insee_unique")
     readonly_fields = ("commune",)
 
     def has_add_permission(self, request) -> bool:

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -557,7 +557,7 @@ class Region(models.Model):
     nom = models.CharField()
 
     def __str__(self) -> str:
-        return self.nom
+        return f"{self.nom} ({self.code_insee})"
 
 
 class Departement(models.Model):
@@ -621,7 +621,7 @@ class Collectivite(models.Model):
     objects = CollectiviteQuerySet.as_manager()
 
     def __str__(self) -> str:
-        return self.nom
+        return f"{self.nom} ({self.code_insee_unique})"
 
     @property
     def code_insee(self) -> str:

--- a/django/users/admin.py
+++ b/django/users/admin.py
@@ -1,7 +1,9 @@
 # ruff: noqa: ANN001, ARG002
-from typing import Literal
+from typing import ClassVar, Literal
 
 from django.contrib import admin
+from django.contrib.postgres.fields import ArrayField
+from django.forms.widgets import TextInput
 
 from users.models import Profile, User
 
@@ -9,8 +11,43 @@ from users.models import Profile, User
 @admin.register(Profile)
 class ProfileAdmin(admin.ModelAdmin):
     readonly_fields = ("user",)
-    search_fields = ("email",)
-    list_filter = ("poste", "side")
+    list_display = (
+        "__str__",
+        "side",
+        "departement",
+        "collectivite",
+        "verified",
+        "is_staff",
+        "is_admin",
+        "email",
+    )
+    list_select_related = ("departement", "collectivite")
+    search_fields = ("email", "firstname", "lastname")
+    list_filter = (
+        ("collectivite_id", admin.EmptyFieldListFilter),
+        "verified",
+        "is_staff",
+        "side",
+        "poste",
+        "region",
+        "departement",
+    )
+
+    autocomplete_fields = ("collectivite",)
+    save_on_top = True
+    radio_fields: ClassVar = {"side": admin.VERTICAL}
+    fields = (
+        ("verified", "is_staff", "is_admin"),
+        "email",
+        ("firstname", "lastname"),
+        ("side", "poste", "other_poste"),
+        ("collectivite", "departement", "region", "departements"),
+        "tel",
+        ("no_signup", "successfully_logged_once", "optin", "updated_pipedrive"),
+    )
+    formfield_overrides: ClassVar = {
+        ArrayField: {"widget": TextInput(attrs={"size": "40"})}
+    }
 
     def has_add_permission(self, request) -> Literal[False]:
         return False


### PR DESCRIPTION
Liste des Profils :
- Permet la recherche par email, firstname et lastname.
- Ajoute des champs.
- Ajoute des filtres.

Page détail d'un Profil :
- Permet de manipuler les collectivités, départements et régions parmi une liste avec leurs noms, plutôt que des champs numériques bruts.
- Cache le champ `created_at` qui ne devrait pas être manipulé.
- Clarifie les champs `is_staff` et `is_admin` avec un autre nom et `help_text`.
- Affiche la liste des valeurs admises dans `other_poste`.
- Side est disponible en tant que boutons radio pour épargner un clic.
- Side n'autorise plus la saisie d'une valeur vide.
- Groupe les champs par catégorie.
- Affiche les boutons de sauvegarde en haut.
- Élargit les champs ArrayField pour afficher une plus grande de leur valeur.

Autre :
- Inclus le code INSEE des collectivités dans leur représentation pour rendre leur sélection dans un champ autocomplete plus agréable.
- Inclus le code INSEE des régions dans leur représentation pour normaliser leur usage.
- Répare la recherche de collectivité par code INSEE en utilisant `code_insee_unique`.

ref https://github.com/MTES-MCT/Docurba/issues/1688
fix https://github.com/MTES-MCT/Docurba/issues/1709