### PR TITLE
Docurba reconnaît les événements Sudocuh structurants

### DIFF
--- a/nuxt/assets/data/events/PLU_events.json
+++ b/nuxt/assets/data/events/PLU_events.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Délibération de prescription du conseil municipal ou communautaire",
+    "lib EV (sur l'outil Sudocuh)": "Prescription",
     "order": 1,
     "law": "Elaboration : art. L. 153-11 du CU\nRevision : art. L. 153-32 du CU",
     "phases": "Définition des modalités",
@@ -391,6 +392,7 @@
   },
   {
     "name": "Débat sur le PADD en conseil municipal",
+    "lib EV (sur l'outil Sudocuh)": "Débat sur le PADD ou PAS",
     "order": 25,
     "law": "L. 153-12 du CU",
     "phases": "PADD",
@@ -863,6 +865,7 @@
   },
   {
     "name": "Réception de l'avis de l'État",
+    "lib EV (sur l'outil Sudocuh)": "Avis de l'État",
     "order": 54,
     "law": "",
     "phases": "Arrêt du projet",
@@ -1115,6 +1118,7 @@
   },
   {
     "name": "Délibération d'approbation du conseil municipal ou communautaire",
+    "lib EV (sur l'outil Sudocuh)": "Délibération d'approbation",
     "order": 69,
     "law": "L. 153-21 (2°)",
     "phases": "Approbation",
@@ -1444,6 +1448,7 @@
   },
   {
     "name": "Abrogation",
+    "lib EV (sur l'outil Sudocuh)": "Arrêté d'abrogation",
     "order": 87,
     "law": "R153-19",
     "phases": "",

--- a/nuxt/assets/data/events/SCOT_events.json
+++ b/nuxt/assets/data/events/SCOT_events.json
@@ -11,6 +11,7 @@
   },
   {
     "name": "Délibération de l'établissement public qui prescrit",
+    "lib EV (sur l'outil Sudocuh)": "Prescription",
     "order": 2,
     "law": "",
     "phases": "Définition des modalités",
@@ -211,6 +212,7 @@
   },
   {
     "name": "Débat sur les orientations du PAS",
+    "lib EV (sur l'outil Sudocuh)": "Arrêté d'abrogation",
     "order": 22,
     "law": "L. 153-12 du CU",
     "phases": "PAS",
@@ -311,6 +313,7 @@
   },
   {
     "name": "Délibération qui arrête le projet de SCoT",
+    "lib EV (sur l'outil Sudocuh)": "Arrêt de projet",
     "order": 32,
     "law": "L. 153-14",
     "phases": "Arrêt du projet",
@@ -401,6 +404,7 @@
   },
   {
     "name": "Réception de l'avis de l'État",
+    "lib EV (sur l'outil Sudocuh)": "Avis de l'État",
     "order": 41,
     "law": "",
     "phases": "Arrêt du projet",

--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -345,7 +345,10 @@ export default
     enrichedEvents () {
       console.log('this.isAdmin: ', this.isAdmin)
       return this.events.map((event) => {
-        const ev = this.documentEvents.find(x => x.name === event.type)
+        const ev = this.documentEvents.find(x =>
+          // Matche le type d'événement en regardant le libellé Docurba ET le libellé Sudocuh
+          [x.name, x["lib EV (sur l'outil Sudocuh)"]].includes(event.type)
+        )
         return { ...event, structurant: !!ev?.structurant }
       }).filter((event) => {
         return event.visibility === 'public' || this.isAdmin || (event.from_sudocuh && event.structurant)


### PR DESCRIPTION
Certains libellés d'événements utilisés par Sudocuh sont disponibles dans Docurba avec un autre libellé. Bien que l'information était disponible dans `CC_events.json` via la clef `lib EV (sur l'outil Sudocuh)`, elle n'était pas exploitée pour savoir si un événement était structurant ou non.

Ce patch permet d'exploiter cette information et la rajoute pour les PLU et les SCoT selon le contenu de https://docs.google.com/spreadsheets/d/1NEcWazdx7LvpnydcyP4pBdFWl9fI_Iu9zy9AQcDtll0/edit?pli=1&gid=1392334617#gid=1392334617.

ref https://github.com/MTES-MCT/Docurba/issues/578