### PR TITLE
Nuxt : afficher l'enquête uniquement aux DDT

### DIFF
--- a/nuxt/pages/ddt/_departement/collectivites/index.vue
+++ b/nuxt/pages/ddt/_departement/collectivites/index.vue
@@ -362,7 +362,7 @@ export default {
       groupements: [],
       filterEpci: null,
       // env.DDT_ENQUETE_ENABLED permet de ne garder l'enquête ouverte que pour des DDT retardataires
-      hasValidationEnabled: true || process.env.DDT_ENQUETE_ENABLED.includes(
+      hasValidationEnabled: this.$user.canViewEnquete() || process.env.DDT_ENQUETE_ENABLED.includes(
         this.$route.params.departement
       ),
       hideValidatedCollectives: false,

--- a/nuxt/plugins/user.js
+++ b/nuxt/plugins/user.js
@@ -184,6 +184,9 @@ export default async ({ $supabase, app }, inject) => {
     },
     canViewMultipleDepartements () {
       return this.profile.side === 'ppa' || this.profile.is_admin
+    },
+    canViewEnquete () {
+      return this.profile.side === 'etat' && this.profile.poste === 'ddt'
     }
   }
 


### PR DESCRIPTION
Le module est actuellement accessible aux PPA alors que ça ne devrait pas.