### PR TITLE
Supabase/recettes jetables : permettre la connexion par lien magique pour les collectivités

### DIFF
--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -69,6 +69,7 @@ jobs:
         env_dict["SUPABASE_ANON_KEY"]=$(echo "${env_vars}" | grep -w "SUPABASE_ANON_KEY" | sed -r 's/SUPABASE_ANON_KEY=//g' | sed -r 's/\"//g')
         env_dict["SUPABASE_ADMIN_KEY"]=$(echo "${env_vars}" | grep -w "SUPABASE_SERVICE_ROLE_KEY" | sed -r 's/SUPABASE_SERVICE_ROLE_KEY=//g' | sed -r 's/\"//g')
         env_dict["SUPABASE_URL"]=$(echo "${env_vars}" | grep -w "SUPABASE_URL" | sed -r 's/SUPABASE_URL=//g' | sed -r 's/\"//g')
+        env_dict["SUPABASE_BRANCH_ID"]=$(echo "${env_dict["SUPABASE_URL"]}" | sed --expression 's/\(https:\/\/\|\.supabase\.co\)//g')
 
         # https://www.chunyangwen.com/blog/shell/bash-array-dict.html
         for key in "${!env_dict[@]}"
@@ -84,11 +85,12 @@ jobs:
     # pour mettre à jour la configuration d'un projet.
     # https://github.com/orgs/supabase/discussions/3765
     # https://supabase.com/docs/reference/cli/supabase-config-push
+    # Une erreur est levée car la variable APP_URL n'est pas encore définie.
+    # Elle l'est plus tard, lors du second envoi.
     - name: 🤹‍♀️ Mise à jour de la configuration de Supabase
       continue-on-error: true
-      run: |
-        supabase_branch_id=$(echo "${SUPABASE_URL}" | sed --expression 's/\(https:\/\/\|\.supabase\.co\)//g')
-        supabase --project-ref "${supabase_branch_id}" --yes config push
+      run: supabase --project-ref "${SUPABASE_BRANCH_ID}" --yes config push
+
 
     - name: 🛠️ Installation de la CLI Scalingo
       uses: scalingo-community/setup-scalingo@87fe86eedc708ffb9d232c756b21f6a5784f6c8a # v0.1.1
@@ -172,6 +174,12 @@ jobs:
 
     - name: 🤹‍♀️ Intégration de l'URL de Django dans Nuxt2
       run: scalingo --app "${NUXT_2_REVIEW_APP_NAME}" env-set APP_URL="${DJANGO_URL}"
+
+    # APP_URL : Supabase est le SSO de Nuxt2. APP_URL est l'URL de redirection après la connexion par lien magique.
+    # Configurée dans supabase/config.toml et dans l'interface : Supabase > Authorization > URL configuration.
+    - name: 🤹‍♀️ Mise à jour de la configuration de Supabase
+      continue-on-error: true
+      run: APP_URL="${DJANGO_URL}" supabase --project-ref "${SUPABASE_BRANCH_ID}" --yes config push
 
     - name: 🍻 Ajout du lien en commentaire de la PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -123,9 +123,9 @@ file_size_limit = "250MB"
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "env(APP_URL)"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["env(APP_URL)"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.


### PR DESCRIPTION
Le SSO de Supabase est utilisé pour construire l'URL de connexion magique pour les collectivités. L'URL de connexion est générée automatiquement par Supabase. Ce dernier récupère l'URL de redirection à partir des paramètres d'authentification configurés dans l'interface.
Heureusement, le fichier supabase/config.toml nous permet de le remplir dynamiquement. Cela nous permet d'activer l'authentification par lien magique dans les recettes jetables.