### PR TITLE
Nuxt : réutilisation de la snackbar entre plusieurs pages

### DIFF
--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -11,14 +11,17 @@
       app
       multi-line
       vertical
-      color="error"
+      :color="snackbar.color"
       :timeout="10000"
     >
       <div>
         {{ snackbar.text }}
       </div>
 
-      <template #action="{ attrs }">
+      <template
+        v-if="snackbar.useActionsTemplate"
+        #action="{ attrs }"
+      >
         <v-btn
           color="white"
           outlined
@@ -51,7 +54,7 @@ export default {
   name: 'DefaultLayout',
   data () {
     return {
-      snackbar: { text: '', val: false }
+      snackbar: { text: '', val: false, color: '', useActionsTemplate: false }
     }
   },
   async mounted () {
@@ -73,7 +76,9 @@ export default {
         }
         this.snackbar = {
           val: true,
-          text: errorMessage
+          text: errorMessage,
+          color: 'error',
+          useActionsTemplate: true
         }
       }
     }
@@ -86,6 +91,11 @@ export default {
           email: this.$route.query.contact
         }
       })
+    }
+    const snackbarDict = localStorage.getItem('snackbarDict')
+    if (snackbarDict) {
+      this.snackbar = { val: true, ...JSON.parse(snackbarDict) }
+      localStorage.removeItem('snackbarDict')
     }
   }
 }

--- a/nuxt/pages/frise/_procedureId/update.vue
+++ b/nuxt/pages/frise/_procedureId/update.vue
@@ -1,0 +1,52 @@
+<template>
+  <div v-if="procedure">
+    <v-container class="px-0 mt-8">
+      <v-row align="end" class="mb-1">
+        <v-col cols="auto">
+          <button
+            class="text-decoration-none d-flex align-center"
+            @click="$router.back()"
+          >
+            <v-icon color="primary" small class="mr-2">
+              {{ icons.mdiChevronLeft }}
+            </v-icon>
+            Retour
+          </button>
+          <h1>Modification de procédure</h1>
+        </v-col>
+      </v-row>
+    </v-container>
+    <!-- <ProceduresUpdateForm :procedure="procedure" /> -->
+  </div>
+  <VGlobalLoader v-else />
+</template>
+<script>
+import { mdiChevronLeft } from '@mdi/js'
+export default {
+  name: 'ProcedureUpdate',
+  data () {
+    return {
+      procedure: null,
+      icons: { mdiChevronLeft },
+      snackbar: { text: '', val: false }
+    }
+  },
+  async mounted () {
+    this.$user.isReady.then(() => {
+      // if (this.$user?.profile?.poste === 'ddt' || this.$user?.profile?.poste === 'dreal') {
+      //   this.$nuxt.setLayout('ddt')
+      // }
+    })
+    const { data: procedure, error: errorProcedure } = await this.$supabase.from('procedures').select('id', 'owner_id').eq('id', this.$route.params.procedureId)
+    if (errorProcedure) { throw errorProcedure }
+    this.procedure = procedure[0]
+
+    if (this.$user.canUpdateProcedure({ procedure: this.procedure })) {
+      // eslint-disable-next-line no-console
+      console.log('Vous ne pouvez pas modifier cette procédure.')
+      localStorage.setItem('snackbarDict', JSON.stringify({ text: 'Vous ne pouvez pas modifier cette procédure.', color: 'error' }))
+      this.$router.back()
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Ce serait utile pour afficher le message si l'utilisateur n'a pas le droit de voir une page (voir commit). Malheureusement, la snackbar n'a pas l'air de survivre à la redirection. À creuser.