### PR TITLE
Django : modifier automatiquement les champs dénormalisés lorsque Procedure.doc_type est modifié

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -385,8 +385,24 @@ class Procedure(models.Model):
             return self.date_prescription < other.date_prescription
         return self.created_at < other.created_at
 
+    def save(self, **kwargs: dict) -> None:
+        self.clean()
+        super().save(**kwargs)
+
     def get_absolute_url(self) -> str:
         return f"/frise/{self.pk}"
+
+    def clean(self) -> None:
+        match self.doc_type:
+            case TypeDocument.SCOT:
+                self.vaut_SCoT = True
+            case TypeDocument.PLUIHM:
+                self.vaut_PLH = True
+                self.vaut_PDM = True
+            case TypeDocument.PLUIH:
+                self.vaut_PLH = True
+            case TypeDocument.PLUIM:
+                self.vaut_PDM = True
 
     _events_processed = False
 

--- a/django/tests/core/test_models.py
+++ b/django/tests/core/test_models.py
@@ -22,6 +22,7 @@ from tests.factories import (
     create_commune,
     create_departement,
     create_groupement,
+    create_procedure,
 )
 
 
@@ -443,6 +444,23 @@ class TestScotInterdepartemental:
 
 
 class TestProcedure:
+    @pytest.mark.django_db
+    def test_save(self) -> None:
+        procedure = create_procedure(doc_type=TypeDocument.SCOT)
+        assert procedure.vaut_SCoT
+
+        # Same as Procedure.vaut_plh_consolide
+        for doc_type in [TypeDocument.PLUIH, TypeDocument.PLUIHM]:
+            perimetre = [create_commune() for _ in range(2)]
+            procedure = create_procedure(doc_type=doc_type, perimetre=perimetre)
+            assert procedure.vaut_PLH
+
+        # Same as Procedure.vaut_pdm_consolide
+        for doc_type in [TypeDocument.PLUIM, TypeDocument.PLUIHM]:
+            perimetre = [create_commune() for _ in range(2)]
+            procedure = create_procedure(doc_type=doc_type, perimetre=perimetre)
+            assert procedure.vaut_PDM
+
     def test_is_schema(self) -> None:
         assert not Procedure(doc_type=TypeDocument.CC).is_schema
         assert not Procedure(doc_type=TypeDocument.PLU).is_schema


### PR DESCRIPTION
- **Django: add Project model and add Procedure's last missing fields**
- **Django: reorganize Procedure and Project model fields**
- **Django: update Procedure denormalized fields on save**
- **Django: move quick fix where perimetre_count is used**
- **Django: add comments**
