### PR TITLE
Dependabot - Cooldown de 7 jours

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/django"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Cela permet d'éviter la majorité des attaques de supply chain.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown- https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns