### PR TITLE
Doc API - Exemples utilisent avant=2026-01-01

### DIFF
--- a/nuxt/content/Dev/API/communes.md
+++ b/nuxt/content/Dev/API/communes.md
@@ -7,7 +7,7 @@ visible: true
 
 https://docurba.beta.gouv.fr/api/communes?departement=01
 
-https://docurba.beta.gouv.fr/api/communes?departement=01&avant=2025-01-01
+https://docurba.beta.gouv.fr/api/communes?departement=01&avant=2026-01-01
 
 ### Description
 

--- a/nuxt/content/Dev/API/perimetres.md
+++ b/nuxt/content/Dev/API/perimetres.md
@@ -7,7 +7,7 @@ visible: true
 
 https://docurba.beta.gouv.fr/api/perimetres?departement=01
 
-https://docurba.beta.gouv.fr/api/perimetres?departement=01&avant=2025-01-01
+https://docurba.beta.gouv.fr/api/perimetres?departement=01&avant=2026-01-01
 
 ### Description
 

--- a/nuxt/content/Dev/API/scots.md
+++ b/nuxt/content/Dev/API/scots.md
@@ -7,7 +7,7 @@ visible: true
 
 https://docurba.beta.gouv.fr/api/scots?departement=01
 
-https://docurba.beta.gouv.fr/api/scots?departement=01&avant=2025-01-01
+https://docurba.beta.gouv.fr/api/scots?departement=01&avant=2026-01-01
 
 ### Description
 


### PR DESCRIPTION
ref https://www.notion.so/docurba/API-modifier-la-date-par-d-faut-au-1er-janvier-2026-309be4d354c08049a2b0e0859acac566?source=copy_link