### PR TITLE
Export SCoT - Utilise `avant` pour déterminer la caducité

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -613,7 +613,9 @@ class CollectiviteQuerySet(models.QuerySet):
                 ),
                 models.Prefetch(
                     "scots__perimetre",
-                    Commune.objects.with_scots().select_related("departement__region"),
+                    Commune.objects.with_scots(avant=avant).select_related(
+                        "departement__region",
+                    ),
                     to_attr="communes",
                 ),
             )


### PR DESCRIPTION
Comme nous ne transmettions pas le paramètre `avant` lors du Prefetch des communes, ce sont les événements à la date de l'export qui étaient prises en compte pour déterminer l'opposabilité. Donc les SCoT avec une date de fin d'échéance entre la date spécifiée dans `avant` et la date de l'export étaient considérés caducs.

fix https://github.com/MTES-MCT/Docurba/issues/1863