### PR TITLE
Admin Django : correction d'une erreur 500 sur la page de détail de procédure PLU

### DIFF
--- a/django/core/models.py
+++ b/django/core/models.py
@@ -533,10 +533,26 @@ class Procedure(models.Model):
 
     @property
     def is_intercommunal(self) -> bool:
+        # self.perimetre_count is set when calling Procedure.objects.with_perimetre_counts
+        # which is always called on the manager (see ProcedureManager.get_queryset).
+        # For the moment, it is mandatory to know if the procedure is_intercommunal.
+        # The self.type_document, using self.is_intercommunal, is used to generate the self representation, thus on the Django admin.
+        # For an unknown reason, the ProcedureManager is used on the "list" view but not on the "change" one.
+        # This should be refactored some day as this hack is quite ugly.
+        if not hasattr(self, "perimetre__count"):
+            self.perimetre__count = self.perimetre.count()
+
         return self.perimetre__count > 1
 
     @property
     def is_sectoriel_consolide(self) -> bool:
+        # self.perimetre_count is set when calling Procedure.objects.with_perimetre_counts
+        # which is always called on the manager (see ProcedureManager.get_queryset).
+        # For the moment, it is mandatory to know if the procedure is_sectoriel_consolide.
+        # This should be refactored some day as this hack is quite ugly.
+        if not hasattr(self, "perimetre__count"):
+            self.perimetre__count = self.perimetre.count()
+
         # TODO Ajouter la vérif de la colonne is_sectoriel  # noqa: FIX002
         return self.communes_adherentes__count > self.perimetre__count
 

--- a/django/tests/core/test_admin.py
+++ b/django/tests/core/test_admin.py
@@ -1,0 +1,16 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from core.models import TypeDocument
+from tests.factories import create_procedure
+
+
+@pytest.mark.parametrize("doc_type", TypeDocument.values)
+@pytest.mark.django_db
+def test_procedure_change_page(admin_client: Client, doc_type: TypeDocument) -> None:
+    procedure = create_procedure(doc_type=doc_type)
+    response = admin_client.get(
+        reverse("admin:core_procedure_change", kwargs={"object_id": procedure.pk})
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
Le calcul du nom de la procédure utilise le type de document qui lui-même utilise l'attribut `procedure.perimetre__count` attribué par la méthode de queryset `Procedure.objects.with_perimetre_counts`.
Cette méthode est toujours appelée via le manager mais, pour une raison que j'ignore encore, elle n'est pas prise en compte dans l'admin Django, plus précisément dans la page de détail des procédures. 