### PR TITLE
1307 5 Historise toutes les modifications d'événement

### DIFF
--- a/django/core/admin.py
+++ b/django/core/admin.py
@@ -5,8 +5,9 @@ from typing import ClassVar
 
 from django.contrib import admin
 from django.db import models
+from pghistory.admin import EventModelAdmin
 
-from core.models import Collectivite, Commune, Event, Procedure
+from core.models import Collectivite, Commune, Event, EventsSnapshot, Procedure
 
 
 @admin.register(Collectivite)
@@ -79,11 +80,28 @@ class EventAdmin(admin.ModelAdmin):
     def has_add_permission(self, request: object) -> bool:
         return False
 
-    def has_change_permission(self, request: object, obj=None) -> bool:
-        return False
-
     def has_delete_permission(self, request, obj=None) -> bool:
         return False
+
+    def get_queryset(self, request) -> models.QuerySet:
+        return (
+            super()
+            .get_queryset(request)
+            .prefetch_related(models.Prefetch("procedure", Procedure.objects.all()))
+        )
+
+
+@admin.register(EventsSnapshot)
+class EventSnapshotAdmin(EventModelAdmin):
+    list_display = (
+        "pgh_obj",
+        "pgh_label",
+        "pgh_created_at",
+        "procedure",
+        "profile",
+        "date_evenement",
+        "is_valid",
+    )
 
     def get_queryset(self, request) -> models.QuerySet:
         return (

--- a/django/core/migrations/0013_eventssnapshot_event_insert_insert_and_more.py
+++ b/django/core/migrations/0013_eventssnapshot_event_insert_insert_and_more.py
@@ -1,0 +1,155 @@
+import django.contrib.postgres.functions
+import django.db.models.deletion
+import pgtrigger.compiler
+import pgtrigger.migrations
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0012_json_to_jsonb"),
+        ("pghistory", "0007_auto_20250421_0444"),
+        ("users", "0004_remove_profile_collectivite_id_profile_collectivite_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EventsSnapshot",
+            fields=[
+                ("pgh_id", models.AutoField(primary_key=True, serialize=False)),
+                ("pgh_created_at", models.DateTimeField(auto_now_add=True)),
+                ("pgh_label", models.TextField(help_text="The event label.")),
+                (
+                    "id",
+                    models.UUIDField(
+                        db_default=django.contrib.postgres.functions.RandomUUID(),
+                        editable=False,
+                        serialize=False,
+                    ),
+                ),
+                ("type", models.CharField(blank=True, null=True)),
+                ("date_evenement", models.DateField(db_column="date_iso", null=True)),
+                ("is_valid", models.BooleanField(db_default=True)),
+                (
+                    "visibility",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("public", "Publique - Visible par le grand public"),
+                            (
+                                "private",
+                                "Privé - Visible uniquement par les collaborateur·ices de la procédure",
+                            ),
+                        ],
+                        db_default="public",
+                        null=True,
+                    ),
+                ),
+                ("description", models.TextField(blank=True, null=True)),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        blank=True,
+                        db_default=django.contrib.postgres.functions.TransactionNow(),
+                        editable=False,
+                        null=True,
+                    ),
+                ),
+                (
+                    "updated_at",
+                    models.DateTimeField(
+                        blank=True,
+                        db_default=django.contrib.postgres.functions.TransactionNow(),
+                        editable=False,
+                        null=True,
+                    ),
+                ),
+                (
+                    "attachements",
+                    models.JSONField(blank=True, editable=False, null=True),
+                ),
+                (
+                    "from_sudocuh",
+                    models.IntegerField(blank=True, editable=False, null=True),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="event",
+            trigger=pgtrigger.compiler.Trigger(
+                name="insert_insert",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    func='INSERT INTO "core_eventssnapshot" ("attachements", "created_at", "date_iso", "description", "from_sudocuh", "id", "is_valid", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "procedure_id", "profile_id", "type", "updated_at", "visibility") VALUES (NEW."attachements", NEW."created_at", NEW."date_iso", NEW."description", NEW."from_sudocuh", NEW."id", NEW."is_valid", _pgh_attach_context(), NOW(), \'insert\', NEW."id", NEW."procedure_id", NEW."profile_id", NEW."type", NEW."updated_at", NEW."visibility"); RETURN NULL;',
+                    hash="07eace67edf897c7d7fcf7ac522cbd13b0bfb06d",
+                    operation="INSERT",
+                    pgid="pgtrigger_insert_insert_137f2",
+                    table="doc_frise_events",
+                    when="AFTER",
+                ),
+            ),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="event",
+            trigger=pgtrigger.compiler.Trigger(
+                name="update_update",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    condition="WHEN (OLD.* IS DISTINCT FROM NEW.*)",
+                    func='INSERT INTO "core_eventssnapshot" ("attachements", "created_at", "date_iso", "description", "from_sudocuh", "id", "is_valid", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "procedure_id", "profile_id", "type", "updated_at", "visibility") VALUES (NEW."attachements", NEW."created_at", NEW."date_iso", NEW."description", NEW."from_sudocuh", NEW."id", NEW."is_valid", _pgh_attach_context(), NOW(), \'update\', NEW."id", NEW."procedure_id", NEW."profile_id", NEW."type", NEW."updated_at", NEW."visibility"); RETURN NULL;',
+                    hash="9f1d73036eace5f85dd6776e354820d2844f5207",
+                    operation="UPDATE",
+                    pgid="pgtrigger_update_update_d4328",
+                    table="doc_frise_events",
+                    when="AFTER",
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="eventssnapshot",
+            name="pgh_context",
+            field=models.ForeignKey(
+                db_constraint=False,
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="+",
+                to="pghistory.context",
+            ),
+        ),
+        migrations.AddField(
+            model_name="eventssnapshot",
+            name="pgh_obj",
+            field=models.ForeignKey(
+                db_constraint=False,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="events",
+                to="core.event",
+            ),
+        ),
+        migrations.AddField(
+            model_name="eventssnapshot",
+            name="procedure",
+            field=models.ForeignKey(
+                db_constraint=False,
+                editable=False,
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="+",
+                related_query_name="+",
+                to="core.procedure",
+            ),
+        ),
+        migrations.AddField(
+            model_name="eventssnapshot",
+            name="profile",
+            field=models.ForeignKey(
+                db_constraint=False,
+                null=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="+",
+                related_query_name="+",
+                to="users.profile",
+            ),
+        ),
+    ]

--- a/django/core/migrations/0014_backfill_eventssnapshot.py
+++ b/django/core/migrations/0014_backfill_eventssnapshot.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0013_eventssnapshot_event_insert_insert_and_more"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+        ALTER TABLE doc_frise_events
+            DISABLE TRIGGER handle_updated_at,
+            DISABLE TRIGGER trigger_event_procedure_status_handler;
+
+        UPDATE doc_frise_events
+        SET
+            updated_at = updated_at + '1ms';
+
+
+        ALTER TABLE doc_frise_events
+            ENABLE TRIGGER handle_updated_at,
+            ENABLE TRIGGER trigger_event_procedure_status_handler;
+        """,
+            reverse_sql=migrations.RunSQL.noop,
+        )
+    ]

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from operator import attrgetter
 from typing import Self
 
+import pghistory
 from django.contrib.postgres.functions import RandomUUID, TransactionNow
 from django.db import connection, models
 from django.db.models.constraints import UniqueConstraint
@@ -565,6 +566,7 @@ class VisibilityChoices(models.TextChoices):
     )
 
 
+@pghistory.track(model_name="EventsSnapshot")
 class Event(models.Model):
     id = models.UUIDField(primary_key=True, db_default=RandomUUID(), editable=False)
     procedure = models.ForeignKey(

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -27,6 +27,7 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[])
 # Application definition
 
 INSTALLED_APPS = [
+    "pghistory.admin",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -37,6 +38,8 @@ INSTALLED_APPS = [
     "django_browser_reload",
     "django_extensions",
     "debug_toolbar",
+    "pgtrigger",
+    "pghistory",
     "core",
     "users",
 ]

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "django-debug-toolbar",
     "django-environ",
     "django-extensions",
+    "django-pghistory",
     "django-revproxy",
     "gunicorn[gevent]",
     "psycopg[binary,pool]",

--- a/django/tests/core/test_admin.py
+++ b/django/tests/core/test_admin.py
@@ -5,14 +5,14 @@ from django.test import Client
 from django.test.client import HTTPStatus
 from django.urls import reverse
 
-from core.models import Event
+from core.models import Event, EventsSnapshot
 from tests.factories import create_procedure
 
 
 def admin_url(model_or_instance: models.Model, page: str) -> str:
     kwargs = None
 
-    if isinstance(model_or_instance.pk, UUID):
+    if isinstance(model_or_instance.pk, (UUID, int)):
         kwargs = {"object_id": model_or_instance.pk}
     return reverse(
         f"admin:{model_or_instance._meta.app_label}_{model_or_instance._meta.model_name}_{page}",  # noqa: SLF001
@@ -34,5 +34,25 @@ class TestEventAdmin:
         dummy_event = procedure.event_set.create(type="Dummy", attachements=[])
 
         url = admin_url(dummy_event, "change")
+        response = admin_client.get(url)
+        assert response.status_code == HTTPStatus.OK
+
+
+class TestEventSnapshotAdmin:
+    def test_event_changelist(self, admin_client: Client) -> None:
+        procedure = create_procedure()
+        _dummy_event = procedure.event_set.create(type="Dummy", attachements=[])
+
+        url = admin_url(EventsSnapshot, "changelist")
+        response = admin_client.get(url)
+        assert response.status_code == HTTPStatus.OK
+
+    def test_event_change(self, admin_client: Client) -> None:
+        procedure = create_procedure()
+        dummy_event = procedure.event_set.create(type="Dummy", attachements=[])
+        snapshot = dummy_event.events.first()
+
+        url = admin_url(snapshot, "change")
+
         response = admin_client.get(url)
         assert response.status_code == HTTPStatus.OK

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -234,6 +234,31 @@ wheels = [
 ]
 
 [[package]]
+name = "django-pghistory"
+version = "3.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-pgtrigger" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/7e/594930ce9cc8ddd9a586ef126f745d9516e307ef48a35a8566da54ca53e8/django_pghistory-3.9.2.tar.gz", hash = "sha256:1d07b75b61501a209330e7fb43fad2b2482f7f0399a36fa91aa7600a03025921", size = 31401, upload-time = "2026-02-17T16:08:21.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/58a0551e951e4b67063e35d3393aeaab2f77bca24b0706ffcd977474e34c/django_pghistory-3.9.2-py3-none-any.whl", hash = "sha256:1623633af429837567dd11469823b9bb3c3f908cc117d60f097d23f3f0622fa2", size = 39929, upload-time = "2026-02-17T16:08:19.894Z" },
+]
+
+[[package]]
+name = "django-pgtrigger"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/3d/ea55015e2e2a8e2230c6a056768512a9660573f8926f87671f166d455936/django_pgtrigger-4.17.0.tar.gz", hash = "sha256:55d297a756b5b6a8e0c533d3323fda1589c699e7d14aa3fff7fa7d774c46363c", size = 32200, upload-time = "2025-12-04T15:46:06.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/47/13c0c23c134cd0f0b0addfbc3ef1477f90d891184d21689f9074b794b00c/django_pgtrigger-4.17.0-py3-none-any.whl", hash = "sha256:06048cdeb57e20987fd0bf7dd673512a1413a08868eea248d70dbb970e967175", size = 36326, upload-time = "2025-12-04T15:46:05.427Z" },
+]
+
+[[package]]
 name = "django-revproxy"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -268,6 +293,7 @@ dependencies = [
     { name = "django-debug-toolbar" },
     { name = "django-environ" },
     { name = "django-extensions" },
+    { name = "django-pghistory" },
     { name = "django-revproxy" },
     { name = "gunicorn", extra = ["gevent"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -292,6 +318,7 @@ requires-dist = [
     { name = "django-debug-toolbar" },
     { name = "django-environ" },
     { name = "django-extensions" },
+    { name = "django-pghistory" },
     { name = "django-revproxy" },
     { name = "gunicorn", extras = ["gevent"] },
     { name = "psycopg", extras = ["binary", "pool"] },


### PR DESCRIPTION
Via la librairie django-pghistory qui utilise des triggers.

- Active la modification d'événements dans Django Admin.
- Affiche les Snapshots successifs dans l'admin.
- Crée les snapshots originels via la 0014_backfill_eventssnapshot.

ref https://github.com/MTES-MCT/Docurba/issues/1307

Note de Céline : cf https://github.com/gip-inclusion/les-emplois/pull/6620