### PR TITLE
1307 4 Admin pour les Event

### DIFF
--- a/django/core/admin.py
+++ b/django/core/admin.py
@@ -1,6 +1,8 @@
 # ruff: noqa: ARG002
 # ruff: noqa: ANN001
 # ruff: noqa: RUF012
+from typing import ClassVar
+
 from django.contrib import admin
 from django.db import models
 
@@ -42,6 +44,53 @@ class ProcedurePerimetreInline(admin.TabularInline):
 
 class EventsInline(admin.TabularInline):
     model = Event
+    show_change_link = True
+    view_on_site = False
+
+
+@admin.register(Event)
+class EventAdmin(admin.ModelAdmin):
+    list_display = "__str__", "procedure", "profile", "date_evenement", "is_valid"
+    list_select_related = ("profile",)
+    search_fields = ("procedure__exact",)
+    autocomplete_fields = ("profile",)
+    radio_fields: ClassVar = {"visibility": admin.VERTICAL}
+
+    readonly_fields = (
+        "id",
+        "procedure",
+        "from_sudocuh",
+        "created_at",
+        "updated_at",
+        "attachements",
+    )
+    fields = (
+        "id",
+        ("procedure", "from_sudocuh"),
+        "type",
+        "date_evenement",
+        ("visibility", "is_valid"),
+        "description",
+        "profile",
+        ("created_at", "updated_at"),
+        "attachements",
+    )
+
+    def has_add_permission(self, request: object) -> bool:
+        return False
+
+    def has_change_permission(self, request: object, obj=None) -> bool:
+        return False
+
+    def has_delete_permission(self, request, obj=None) -> bool:
+        return False
+
+    def get_queryset(self, request) -> models.QuerySet:
+        return (
+            super()
+            .get_queryset(request)
+            .prefetch_related(models.Prefetch("procedure", Procedure.objects.all()))
+        )
 
 
 @admin.register(Procedure)

--- a/django/core/migrations/0012_json_to_jsonb.py
+++ b/django/core/migrations/0012_json_to_jsonb.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0011_communeprocedure_commune_id"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""ALTER TABLE "doc_frise_events"
+            ALTER COLUMN "actors" SET DATA TYPE jsonb,
+            ALTER COLUMN "attachements" SET DATA TYPE jsonb
+            """,
+            reverse_sql="""ALTER TABLE "doc_frise_events"
+            ALTER COLUMN "actors" SET DATA TYPE json,
+            ALTER COLUMN "attachements" SET DATA TYPE json
+            """,
+        )
+    ]

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -595,7 +595,10 @@ class Event(models.Model):
         ordering = ("-date_evenement",)
 
     def __str__(self) -> str:
-        return f"{self.procedure}  - {self.type}"
+        return self.type
+
+    def get_absolute_url(self) -> str:
+        return self.procedure.get_absolute_url()
 
     @property
     def category(self) -> EventCategory | None:

--- a/django/tests/conftest.py
+++ b/django/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from pytest_django.fixtures import SettingsWrapper
+
+
+@pytest.fixture(autouse=True)
+def disable_whitenoise(settings: SettingsWrapper) -> None:
+    # > During testing, ensure that staticfiles storage backend in the STORAGES setting
+    # is set to something else like 'django.contrib.staticfiles.storage.StaticFilesStorage'
+    # https://docs.djangoproject.com/en/6.0/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict
+    settings.STORAGES = {
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        }
+    }

--- a/django/tests/core/test_admin.py
+++ b/django/tests/core/test_admin.py
@@ -1,0 +1,38 @@
+from uuid import UUID
+
+from django.db import models
+from django.test import Client
+from django.test.client import HTTPStatus
+from django.urls import reverse
+
+from core.models import Event
+from tests.factories import create_procedure
+
+
+def admin_url(model_or_instance: models.Model, page: str) -> str:
+    kwargs = None
+
+    if isinstance(model_or_instance.pk, UUID):
+        kwargs = {"object_id": model_or_instance.pk}
+    return reverse(
+        f"admin:{model_or_instance._meta.app_label}_{model_or_instance._meta.model_name}_{page}",  # noqa: SLF001
+        kwargs=kwargs,
+    )
+
+
+class TestEventAdmin:
+    def test_event_changelist(self, admin_client: Client) -> None:
+        procedure = create_procedure()
+        _dummy_event = procedure.event_set.create(type="Dummy", attachements=[])
+
+        url = admin_url(Event, "changelist")
+        response = admin_client.get(url)
+        assert response.status_code == HTTPStatus.OK
+
+    def test_event_change(self, admin_client: Client) -> None:
+        procedure = create_procedure()
+        dummy_event = procedure.event_set.create(type="Dummy", attachements=[])
+
+        url = admin_url(dummy_event, "change")
+        response = admin_client.get(url)
+        assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
- Modification bloquée tant que l'historisation n'est pas mise en place.
- Permet de naviguer depuis l'admin d'une Procédure vers les événements.
- Convertit les colonnes `json` en `jsonb` car nécessaire pour afficher de tels champs dans l'admin. Cela est aussi utile pour django-pghistory qui ne peut pas comparer des colonnes `json`.

Tests :
- Ajoute des tests pour les pages Event de l'admin.
- Désactive Whitenoise pour que les tests puissent marcher.

ref https://github.com/MTES-MCT/Docurba/issues/1307