### PR TITLE
Django envs: réinstallation de trois dépendances de dev en prod

### DIFF
--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -12,14 +12,15 @@ dependencies = [
     "sentry-sdk[django]",
     "whitenoise[brotli]",
     "django-datadog-logger", # https://github.com/namespace-ee/django-datadog-logger
+    # Move me later.
+    "django-browser-reload",
+    "django-debug-toolbar",
+    "django-extensions",
 ]
 
 # Scalingo command: `uv sync --locked --no-default-groups`
 [dependency-groups]
 dev = [
-    "django-browser-reload",
-    "django-debug-toolbar",
-    "django-extensions",
     "ptpython",
     "pytest-cov",
     "pytest-django",

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -263,8 +263,11 @@ version = "1"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-browser-reload" },
     { name = "django-datadog-logger" },
+    { name = "django-debug-toolbar" },
     { name = "django-environ" },
+    { name = "django-extensions" },
     { name = "django-revproxy" },
     { name = "gunicorn", extra = ["gevent"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -274,9 +277,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "django-browser-reload" },
-    { name = "django-debug-toolbar" },
-    { name = "django-extensions" },
     { name = "pre-commit" },
     { name = "ptpython" },
     { name = "pytest-cov" },
@@ -287,8 +287,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django" },
+    { name = "django-browser-reload" },
     { name = "django-datadog-logger" },
+    { name = "django-debug-toolbar" },
     { name = "django-environ" },
+    { name = "django-extensions" },
     { name = "django-revproxy" },
     { name = "gunicorn", extras = ["gevent"] },
     { name = "psycopg", extras = ["binary", "pool"] },
@@ -298,9 +301,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "django-browser-reload" },
-    { name = "django-debug-toolbar" },
-    { name = "django-extensions" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "ptpython" },
     { name = "pytest-cov" },


### PR DESCRIPTION
Elles étaient installées et utilisées en prod. Le déploiement casse car le code qui tourne semble encore les utiliser.