### PR TITLE
Django : utiliser la version 9.0 de Pytest

### DIFF
--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "django-extensions",
     "ptpython",
     "pytest-cov",
+    "pytest>=9.0",
     "pytest-django",
     "ruff",
     "pre-commit>=4.3.0", # https://github.com/pre-commit/pre-commit

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -279,6 +279,7 @@ dev = [
     { name = "django-extensions" },
     { name = "pre-commit" },
     { name = "ptpython" },
+    { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "ruff" },
@@ -303,6 +304,7 @@ dev = [
     { name = "django-extensions" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "ptpython" },
+    { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "ruff" },
@@ -574,17 +576,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The 9.0 version add subtests, which I want to use in a test suite.
ihttps://docs.pytest.org/en/stable/how-to/subtests.html

The pytest-django package installs the last available version
but its last release is more than one year old.
To make sure this project uses the right Pytest version, pin it.
