### PR TITLE
[Django] performance des API : profiling avec Django-Silk et diverses pistes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,6 @@ copy_exports_from_outscale:
 
 move_exports_from_outscale:
 	cd django && direnv exec . rclone --config scripts/rclone.conf move --s3-chunk-size=20M docurba_exports:/docurba-exports exports/
+
+delete_silk_files:
+	find -name "*.prof" -delete

--- a/django/.env.example
+++ b/django/.env.example
@@ -26,3 +26,4 @@ export SUPABASE_ACCESS_TOKEN=""
 
 # Tests
 export TEST_DATABASE_URL="postgres://postgres:postgres@127.0.0.1:5432/test_docurba"
+export SILK_PROFILE_ENABLED=True

--- a/django/config/settings/dev.py
+++ b/django/config/settings/dev.py
@@ -28,6 +28,15 @@ TEMPLATES[0]["OPTIONS"]["context_processors"].append(
     "django.template.context_processors.debug"
 )
 
+SILKY_ENABLED = env.str("SILK_PROFILE_ENABLED", default="False")
+
+if SILKY_ENABLED == "True":
+    SILKY_PYTHON_PROFILER = True
+    SILKY_PYTHON_PROFILER_BINARY = True
+    INSTALLED_APPS.append("silk")
+    MIDDLEWARE.append("silk.middleware.SilkyMiddleware")
+
+
 # Don't use json formatter in dev
 del LOGGING["handlers"]["console"]["formatter"]
 

--- a/django/config/urls.py
+++ b/django/config/urls.py
@@ -66,4 +66,7 @@ if settings.DEBUG:
     if "django_browser_reload" in settings.INSTALLED_APPS:
         urls.append(path("__reload__/", include("django_browser_reload.urls")))
 
+    if "silk" in settings.INSTALLED_APPS:
+        urls.append(path("silk/", include("silk.urls", namespace="silk")))
+
     urlpatterns = [*urls, *urlpatterns]

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -260,6 +260,18 @@ class ProcedureStatusChoices(models.TextChoices):
 
 
 class ProcedureQuerySet(models.QuerySet):
+    def with_is_interdepartemental(self) -> Self:
+        return self.annotate(
+            count_communes_departements=models.Count(
+                models.F("perimetre__departement_id"), distinct=True
+            )
+        ).annotate(
+            is_interdepartemental=models.Case(
+                models.When(models.Q(count_communes_departements__gt=1), then=True),
+                default=False,
+            )
+        )
+
     def with_events(self, *, avant: date | None = None) -> Self:
         events = Event.objects.exclude(date_evenement=None)
         return self.annotate(
@@ -682,7 +694,9 @@ class CollectiviteQuerySet(models.QuerySet):
             .prefetch_related(
                 models.Prefetch(
                     "procedure_set",
+                    #         return len({commune.departement for commune in self.communes}) > 1
                     Procedure.objects.defer("current_perimetre", "initial_perimetre")
+                    # .with_is_interdepartemental()
                     .with_events(avant=avant)
                     .without_adhesions_count()
                     .order_by("created_at")

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -352,7 +352,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
                 "pa_date_approbation": scot_opposable.date_approbation,
                 "pa_annee_approbation": scot_opposable.date_approbation.year,
                 "pa_date_fin_echeance": scot_opposable.date_fin_echeance,
-                "pa_nombre_communes": len(scot_opposable.communes),
+                # "pa_nombre_communes": len(scot_opposable.communes),
             }
 
         champs_en_cours = {}
@@ -366,7 +366,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
                 "pc_date_publication_perimetre": scot_en_cours.date_publication_perimetre,
                 "pc_date_prescription": scot_en_cours.date_prescription,
                 "pc_date_arret_projet": scot_en_cours.date_arret_projet,
-                "pc_nombre_communes": len(scot_en_cours.communes),
+                # "pc_nombre_communes": len(scot_en_cours.communes),
             }
 
         return champs_groupement | champs_opposable | champs_en_cours

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -3,11 +3,7 @@ from datetime import date
 from itertools import groupby
 from operator import attrgetter
 
-from django.http import (
-    HttpRequest,
-    HttpResponseBadRequest,
-    StreamingHttpResponse,
-)
+from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_safe
 
@@ -22,20 +18,8 @@ def _avant(request: HttpRequest) -> date | None:
     )
 
 
-class Echo:
-    """False buffer.
-
-    An object that implements just the write method of the file-like
-    interface.
-    """
-
-    def write(self, value: str) -> str:
-        """Write the value by returning it, instead of storing in a buffer."""
-        return value
-
-
 @require_safe
-def api_perimetres(request: HttpRequest) -> StreamingHttpResponse:
+def api_perimetres(request: HttpRequest) -> HttpResponse:
     try:
         avant = _avant(request)
     except ValueError:
@@ -49,10 +33,10 @@ def api_perimetres(request: HttpRequest) -> StreamingHttpResponse:
     if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 
-    pseudo_buffer = Echo()
+    response = HttpResponse(content_type="text/csv;charset=utf-8")
 
     csv_writer = DictWriter(
-        pseudo_buffer,
+        response,
         dialect="unix",
         fieldnames=[
             "annee_cog",
@@ -63,29 +47,24 @@ def api_perimetres(request: HttpRequest) -> StreamingHttpResponse:
             "opposable",
         ],
     )
-    return StreamingHttpResponse(
-        (
-            csv_writer.writeheader(),
-            csv_writer.writerows(
-                {
-                    "annee_cog": "2024",
-                    "collectivite_code": commune.code_insee,
-                    "collectivite_type": commune.type,
-                    "procedure_id": procedure.id,
-                    "type_document": procedure.type_document,
-                    "opposable": commune.is_opposable(procedure),
-                }
-                for commune in communes.iterator(chunk_size=1000)
-                for procedure in commune.procedures_principales
-            ),
-        ),
-        content_type="text/csv;charset=utf-8",
-        headers={"Content-Disposition": 'attachment; filename="perimetres.csv"'},
+    csv_writer.writeheader()
+    csv_writer.writerows(
+        {
+            "annee_cog": "2024",
+            "collectivite_code": commune.code_insee,
+            "collectivite_type": commune.type,
+            "procedure_id": procedure.id,
+            "type_document": procedure.type_document,
+            "opposable": commune.is_opposable(procedure),
+        }
+        for commune in communes.iterator(chunk_size=1000)
+        for procedure in commune.procedures_principales
     )
+    return response
 
 
 @require_safe
-def api_communes(request: HttpRequest) -> StreamingHttpResponse:
+def api_communes(request: HttpRequest) -> HttpResponse:
     try:
         avant = _avant(request)
     except ValueError:
@@ -101,9 +80,9 @@ def api_communes(request: HttpRequest) -> StreamingHttpResponse:
     if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 
-    pseudo_buffer = Echo()
+    response = HttpResponse(content_type="text/csv;charset=utf-8")
     csv_writer = DictWriter(
-        pseudo_buffer,
+        response,
         dialect="unix",
         fieldnames=[
             "annee_cog",
@@ -285,20 +264,15 @@ def api_communes(request: HttpRequest) -> StreamingHttpResponse:
             | champs_en_cours
         )
 
-    return StreamingHttpResponse(
-        (
-            csv_writer.writeheader(),
-            csv_writer.writerows(
-                format_row(commune) for commune in communes.iterator(chunk_size=1000)
-            ),
-        ),
-        content_type="text/csv;charset=utf-8",
-        headers={"Content-Disposition": 'attachment; filename="communes.csv"'},
+    csv_writer.writeheader()
+    csv_writer.writerows(
+        format_row(commune) for commune in communes.iterator(chunk_size=1000)
     )
+    return response
 
 
 @require_safe
-def api_scots(request: HttpRequest) -> StreamingHttpResponse:
+def api_scots(request: HttpRequest) -> HttpResponse:
     try:
         avant = _avant(request)
     except ValueError:
@@ -310,9 +284,9 @@ def api_scots(request: HttpRequest) -> StreamingHttpResponse:
     if departement := request.GET.get("departement"):
         collectivites = collectivites.filter(departement__code_insee=departement)
 
-    pseudo_buffer = Echo()
+    response = HttpResponse(content_type="text/csv;charset=utf-8")
     csv_writer = DictWriter(
-        pseudo_buffer,
+        response,
         dialect="unix",
         fieldnames=[
             "annee_cog",
@@ -397,24 +371,19 @@ def api_scots(request: HttpRequest) -> StreamingHttpResponse:
 
         return champs_groupement | champs_opposable | champs_en_cours
 
-    return StreamingHttpResponse(
-        (
-            csv_writer.writeheader(),
-            csv_writer.writerows(
-                format_row(collectivite, scot_opposable, scot_en_cours)
-                for collectivite in collectivites.iterator(chunk_size=1000)
-                for scot_opposable, scot_en_cours in collectivite.scots_pour_csv
-            ),
-        ),
-        content_type="text/csv;charset=utf-8",
-        headers={"Content-Disposition": 'attachment; filename="scots.csv"'},
+    csv_writer.writeheader()
+    csv_writer.writerows(
+        format_row(collectivite, scot_opposable, scot_en_cours)
+        for collectivite in collectivites.iterator(chunk_size=1000)
+        for scot_opposable, scot_en_cours in collectivite.scots_pour_csv
     )
+    return response
 
 
 @require_safe
 def collectivite(
     request: HttpRequest, collectivite_code: str, collectivite_type: str = "COM"
-) -> StreamingHttpResponse:
+) -> HttpResponse:
     try:
         avant = _avant(request)
     except ValueError:

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -3,7 +3,11 @@ from datetime import date
 from itertools import groupby
 from operator import attrgetter
 
-from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
+from django.http import (
+    HttpRequest,
+    HttpResponseBadRequest,
+    StreamingHttpResponse,
+)
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_safe
 
@@ -18,8 +22,20 @@ def _avant(request: HttpRequest) -> date | None:
     )
 
 
+class Echo:
+    """False buffer.
+
+    An object that implements just the write method of the file-like
+    interface.
+    """
+
+    def write(self, value: str) -> str:
+        """Write the value by returning it, instead of storing in a buffer."""
+        return value
+
+
 @require_safe
-def api_perimetres(request: HttpRequest) -> HttpResponse:
+def api_perimetres(request: HttpRequest) -> StreamingHttpResponse:
     try:
         avant = _avant(request)
     except ValueError:
@@ -33,10 +49,10 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
     if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 
-    response = HttpResponse(content_type="text/csv;charset=utf-8")
+    pseudo_buffer = Echo()
 
     csv_writer = DictWriter(
-        response,
+        pseudo_buffer,
         dialect="unix",
         fieldnames=[
             "annee_cog",
@@ -47,24 +63,29 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
             "opposable",
         ],
     )
-    csv_writer.writeheader()
-    csv_writer.writerows(
-        {
-            "annee_cog": "2024",
-            "collectivite_code": commune.code_insee,
-            "collectivite_type": commune.type,
-            "procedure_id": procedure.id,
-            "type_document": procedure.type_document,
-            "opposable": commune.is_opposable(procedure),
-        }
-        for commune in communes.iterator(chunk_size=1000)
-        for procedure in commune.procedures_principales
+    return StreamingHttpResponse(
+        (
+            csv_writer.writeheader(),
+            csv_writer.writerows(
+                {
+                    "annee_cog": "2024",
+                    "collectivite_code": commune.code_insee,
+                    "collectivite_type": commune.type,
+                    "procedure_id": procedure.id,
+                    "type_document": procedure.type_document,
+                    "opposable": commune.is_opposable(procedure),
+                }
+                for commune in communes.iterator(chunk_size=1000)
+                for procedure in commune.procedures_principales
+            ),
+        ),
+        content_type="text/csv;charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="perimetres.csv"'},
     )
-    return response
 
 
 @require_safe
-def api_communes(request: HttpRequest) -> HttpResponse:
+def api_communes(request: HttpRequest) -> StreamingHttpResponse:
     try:
         avant = _avant(request)
     except ValueError:
@@ -80,9 +101,9 @@ def api_communes(request: HttpRequest) -> HttpResponse:
     if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 
-    response = HttpResponse(content_type="text/csv;charset=utf-8")
+    pseudo_buffer = Echo()
     csv_writer = DictWriter(
-        response,
+        pseudo_buffer,
         dialect="unix",
         fieldnames=[
             "annee_cog",
@@ -264,15 +285,20 @@ def api_communes(request: HttpRequest) -> HttpResponse:
             | champs_en_cours
         )
 
-    csv_writer.writeheader()
-    csv_writer.writerows(
-        format_row(commune) for commune in communes.iterator(chunk_size=1000)
+    return StreamingHttpResponse(
+        (
+            csv_writer.writeheader(),
+            csv_writer.writerows(
+                format_row(commune) for commune in communes.iterator(chunk_size=1000)
+            ),
+        ),
+        content_type="text/csv;charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="communes.csv"'},
     )
-    return response
 
 
 @require_safe
-def api_scots(request: HttpRequest) -> HttpResponse:
+def api_scots(request: HttpRequest) -> StreamingHttpResponse:
     try:
         avant = _avant(request)
     except ValueError:
@@ -284,9 +310,9 @@ def api_scots(request: HttpRequest) -> HttpResponse:
     if departement := request.GET.get("departement"):
         collectivites = collectivites.filter(departement__code_insee=departement)
 
-    response = HttpResponse(content_type="text/csv;charset=utf-8")
+    pseudo_buffer = Echo()
     csv_writer = DictWriter(
-        response,
+        pseudo_buffer,
         dialect="unix",
         fieldnames=[
             "annee_cog",
@@ -371,19 +397,24 @@ def api_scots(request: HttpRequest) -> HttpResponse:
 
         return champs_groupement | champs_opposable | champs_en_cours
 
-    csv_writer.writeheader()
-    csv_writer.writerows(
-        format_row(collectivite, scot_opposable, scot_en_cours)
-        for collectivite in collectivites.iterator(chunk_size=1000)
-        for scot_opposable, scot_en_cours in collectivite.scots_pour_csv
+    return StreamingHttpResponse(
+        (
+            csv_writer.writeheader(),
+            csv_writer.writerows(
+                format_row(collectivite, scot_opposable, scot_en_cours)
+                for collectivite in collectivites.iterator(chunk_size=1000)
+                for scot_opposable, scot_en_cours in collectivite.scots_pour_csv
+            ),
+        ),
+        content_type="text/csv;charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="scots.csv"'},
     )
-    return response
 
 
 @require_safe
 def collectivite(
     request: HttpRequest, collectivite_code: str, collectivite_type: str = "COM"
-) -> HttpResponse:
+) -> StreamingHttpResponse:
     try:
         avant = _avant(request)
     except ValueError:

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "ruff",
     "pre-commit>=4.3.0", # https://github.com/pre-commit/pre-commit
     "factory-boy", # https://github.com/FactoryBoy/factory_boy
+    "django-silk>=5.4.3",
 ]
 
 [tool.pytest.ini_options]

--- a/django/tests/core/factories.py
+++ b/django/tests/core/factories.py
@@ -121,7 +121,9 @@ class CollectiviteFactory(factory.django.DjangoModelFactory):
     )
 
     nom = factory.LazyAttribute(
-        lambda o: f"{o.type} {factory.Faker('company', locale='fr_FR')}"
+        lambda o: (
+            f"{o.type} {factory.Faker('company', locale='fr_FR').evaluate(None, None, {'locale': 'fr_FR'})}"
+        )
     )
     competence_plan = False
     competence_schema = False

--- a/django/tests/core/test_views.py
+++ b/django/tests/core/test_views.py
@@ -284,7 +284,7 @@ class TestAPIScots:
                 "scot_code_departement": collectivite.departement.code_insee,
                 "scot_lib_departement": collectivite.departement.nom,
                 "scot_codecollectivite": collectivite.code_insee,
-                "scot_code_type_collectivite": collectivite.type,
+                "scot_code_type_collectivite": collectivite.type.name,
                 "scot_nom_collectivite": collectivite.nom,
                 # Approuvée
                 "pa_id": "",

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -246,6 +246,20 @@ wheels = [
 ]
 
 [[package]]
+name = "django-silk"
+version = "5.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "gprof2dot" },
+    { name = "sqlparse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/13/ef9344e4ed6ab6ed0f15d7743e9509545e95f3336ac9bbef4b39aefbabeb/django_silk-5.4.3.tar.gz", hash = "sha256:bedb17c8fd9c029a7746cb947864f5c9ea943ae33d6a9581e60f67c45e4490ad", size = 4495552, upload-time = "2025-09-09T07:13:30.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/97/bc1f1d0f922144a3807ad15531b93ba474c7538d6f006e98bf8ab77a2f82/django_silk-5.4.3-py3-none-any.whl", hash = "sha256:f7920ae91a34716654296140b2cbf449e9798237a0c6eb7cf2cd79c2cfb39321", size = 1944434, upload-time = "2025-09-09T07:13:50.846Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -278,6 +292,7 @@ dev = [
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
     { name = "factory-boy" },
+    { name = "django-silk" },
     { name = "pre-commit" },
     { name = "ptpython" },
     { name = "pytest" },
@@ -304,6 +319,7 @@ dev = [
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
     { name = "factory-boy" },
+    { name = "django-silk", specifier = ">=5.4.3" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "ptpython" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -365,6 +381,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/6e/b2eed8dec617264f0046d50a13a42d3f0a06c50071b9fc1eae00285a03f1/gevent-24.11.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:58851f23c4bdb70390f10fc020c973ffcf409eb1664086792c8b1e20f25eef43", size = 5449436, upload-time = "2024-11-11T15:37:08.143Z" },
     { url = "https://files.pythonhosted.org/packages/63/c2/eca6b95fbf9af287fa91c327494e4b74a8d5bfa0156cd87b233f63f118dc/gevent-24.11.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1ea50009ecb7f1327347c37e9eb6561bdbc7de290769ee1404107b9a9cba7cf1", size = 6866470, upload-time = "2024-11-11T15:03:48.724Z" },
     { url = "https://files.pythonhosted.org/packages/b7/e6/51824bd1f2c1ce70aa01495aa6ffe04ab789fa819fa7e6f0ad2388fb03c6/gevent-24.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:ec68e270543ecd532c4c1d70fca020f90aa5486ad49c4f3b8b2e64a66f5c9274", size = 1540088, upload-time = "2024-11-11T14:46:23.849Z" },
+]
+
+[[package]]
+name = "gprof2dot"
+version = "2025.4.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/fd/cad13fa1f7a463a607176432c4affa33ea162f02f58cc36de1d40d3e6b48/gprof2dot-2025.4.14.tar.gz", hash = "sha256:35743e2d2ca027bf48fa7cba37021aaf4a27beeae1ae8e05a50b55f1f921a6ce", size = 39536, upload-time = "2025-04-14T07:21:45.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/ed/89d760cb25279109b89eb52975a7b5479700d3114a2421ce735bfb2e7513/gprof2dot-2025.4.14-py3-none-any.whl", hash = "sha256:0742e4c0b4409a5e8777e739388a11e1ed3750be86895655312ea7c20bd0090e", size = 37555, upload-time = "2025-04-14T07:21:43.319Z" },
 ]
 
 [[package]]

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -291,8 +291,8 @@ dev = [
     { name = "django-browser-reload" },
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
-    { name = "factory-boy" },
     { name = "django-silk" },
+    { name = "factory-boy" },
     { name = "pre-commit" },
     { name = "ptpython" },
     { name = "pytest" },
@@ -318,8 +318,8 @@ dev = [
     { name = "django-browser-reload" },
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
-    { name = "factory-boy" },
     { name = "django-silk", specifier = ">=5.4.3" },
+    { name = "factory-boy" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "ptpython" },
     { name = "pytest", specifier = ">=9.0.3" },


### PR DESCRIPTION
- Augmenter le plan dans l'immédiat.
- nettoyer la colonne type d'événement pour ne garder que les enums (et utiliser des enums, idéalement)
- Travailler sur le calcul du statut des procédures.

[Lien vers la documentation de Django Silk](https://github.com/jazzband/django-silk)

Testé sur l'API Scot avec `curl -I localhost:8000/api/scots`.
- 6 requêtes en base de données. Temps de réponse : environ 8 secondes.
- Temps de réponse total moyen : 18 secondes.
- Donc temps pour générer le CSV et le reste : 10 secondes.

Idées d'optimisations :
- Faire du raw sql.
- Mieux utiliser les queryset pour évaluer en bas niveau ce qui peut l'être. Se passer des len() à remplacer par des count en base. Plus d'autres aspects à creuser.
- Ne plus utiliser DictWriter mais récupérer uniquement le nécessaire et utiliser .values_list. [Faster CSV export from the Django admin](https://ellen.dev/faster-csv-export-django-admin.html). Pour cela, remplacer les `prefetch_related` qui génèrent des attributs par des annotations. Chaîner les annotations dans la vue pour rendre la requête à l'ORM plus explicite. 
- :heavy_equals_sign: Utiliser `StreamingHttpResponse` au lieu de `HttpResponse`. [How to create CSV output (from Django's doc](https://docs.djangoproject.com/en/6.0/howto/outputting-csv/). => Pas probant. Gain moyen : 1 seconde (API scot).
- :heavy_equals_sign:  Forcer l'utilisation des only et defer : https://github.com/charettes/django-seal => pas probant.

Fait :
- :+1:  Augmentation drastique du plan Supabase à L : les performances seront équivalentes à l'environnement local. L'API Communes ne peut toujours pas être appelée dans la France entière.
 
Les `prefetch` semblent être les plus coûteux en temps car ils passent une liste de PK très longue. Une requête pèse 800ko.

En cours :
- [ ] Récupérer `_scots_opposables` à partir de la DB.
- [ ] Supprimer les index non utilisés

```sql
select * from pg_stat_all_indexes as stats where stats.schemaname = 'public' and stats.indexrelname = 'test_index'
-- PG 16 introduced the last_seq_scan column which could tell us if the index is used but we still are under 15. 
```

From the CProfile :

```
      477    0.000    0.000    0.480    0.001 /home/cms/sites/docurba/django/docurba/core/models.py:764(scots_pour_csv)
      477    0.001    0.000    0.474    0.001 /home/cms/sites/docurba/django/docurba/core/models.py:742(_scots_opposables)
1743/1677    0.002    0.000    0.443    0.000 {built-in method builtins.any}
     4472    0.003    0.000    0.437    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:748(<genexpr>)
     4402    0.005    0.000    0.434    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:914(is_opposable)
     4402    0.003    0.000    0.402    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:873(plan_opposable)
     4509    0.009    0.000    0.386    0.000 {built-in method builtins.sorted}
     4402    0.003    0.000    0.386    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:850(procedures_principales_approuvees)
    12477    0.014    0.000    0.380    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:438(statut)
    18/12    0.001    0.000    0.378    0.031 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py:756(as_sql)
  518/302    0.001    0.000    0.371    0.001 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py:573(compile)
    22/18    0.000    0.000    0.365    0.020 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/sql/where.py:116(as_sql)
    13750    0.009    0.000    0.351    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:853(<genexpr>)
       24    0.000    0.000    0.342    0.014 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/psycopg/_cursor_base.py:450(_convert_query)
       24    0.000    0.000    0.337    0.014 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/psycopg/_queries.py:240(convert)
    10565    0.014    0.000    0.314    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:423(dernier_event_impactant)
       12    0.019    0.002    0.305    0.025 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/psycopg/_queries.py:291(_query2pg_client_nocache)
       22    0.000    0.000    0.301    0.014 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/sql/query.py:1420(build_lookup)
   103715    0.079    0.000    0.281    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/fields/related_descriptors.py:1170(<lambda>)
       12    0.228    0.019    0.277    0.023 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/psycopg/_queries.py:346(_split_query)
    55088    0.051    0.000    0.270    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:411(_process_events)
    53594    0.032    0.000    0.262    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/backends/postgresql/psycopg_any.py:33(load)
        1    0.241    0.241    0.261    0.261 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/query.py:1367(_prefetch_related_objects)
   108144    0.043    0.000    0.239    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/fields/related.py:810(get_foreign_related_value)
945655/945654    0.179    0.000    0.238    0.000 {method 'get' of 'dict' objects}
    51823    0.044    0.000    0.235    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/fields/related_descriptors.py:1177(<lambda>)
   141055    0.128    0.000    0.225    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/fields/related.py:813(get_instance_value_for_fields)
105903/105901    0.050    0.000    0.222    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/django/db/models/fields/related.py:1190(get_prep_value)
  2023061    0.220    0.000    0.220    0.000 {built-in method builtins.isinstance}
    53594    0.018    0.000    0.220    0.000 /home/cms/sites/docurba/django/.venv/lib/python3.13/site-packages/psycopg/types/datetime.py:508(load)
   194486    0.101    0.000    0.210    0.000 /home/cms/sites/docurba/django/docurba/core/models.py:647(category)
```

--

## Temps de réponse avec un plan Scalingo M

### Plan actuel
- API Communes : ne répond pas (temps de réponse supérieur à 1m)
- API SCoTs : 0m26,828s
- API Périmètres : ne répond pas (temps de réponse supérieur à 1m)

### Plan Supabase L (après passage en XL), 12GB de disque

- API Communes : 0m45,644s
- API SCoTs : 0m18,354s
- API Périmètres : 0m39,601s


### Plan Supabase XL

(France entière)

- API Communes : 0m47,534s
- API SCoTs : 0m34,158s
- API Périmètres : 0m51,144s
- 
-  
Mentionné pour la gloire : [Django: profile memory usage with Memray from Adam Johnson](https://adamj.eu/tech/2026/01/29/django-profile-memray/). Testé mais difficile à utiliser pour profiler des requêtes Django. La DDT intègre bien une section Profiling mais qui ne me permettait pas de descendre au niveau souhaité.

--


    Django: profile memory usage with Silky or Memray
    
    Calls to our API endpoints are preventing various models evolutions
    because adding fields to them cause the API to responds more slowly.
    Try to understand where the problem come from and how to resolve it.
    
    https://bloomberg.github.io/memray/getting_started.html
    https://adamj.eu/tech/2026/01/29/django-profile-memray/