### PR TITLE
feat: ajout d'un texte explicatif sur la page de connexion (#1867)

### DIFF
--- a/nuxt/pages/login/index.vue
+++ b/nuxt/pages/login/index.vue
@@ -14,6 +14,18 @@
         <div class="text-h1">
           Inscription et connexion
         </div>
+
+        <p class="mt-4 text-body-1 g600--text">
+          Les données publiques de Docurba sont accessibles librement, sans compte, en naviguant
+          sur le site ou en consultant nos
+          <nuxt-link to="/exports" class="text-decoration-underline">
+            API.
+          </nuxt-link>
+        </p>
+        <p class="text-body-1 g600--text">
+          La création de compte Docurba est réservée aux acteurs de la planification pour
+          contribuer notamment au suivi de leurs documents d'urbanisme en cours d'élaboration.
+        </p>
       </v-col>
     </v-row>
     <v-row class="d-flex align-self-start">


### PR DESCRIPTION
## Résumé
- Ajout de deux paragraphes sur la page de connexion entre le titre et les cartes de choix de rôle
- Précise que les données publiques sont accessibles librement sans compte
- Lien "API" vers la page `/exports` avec soulignement
- Indique que la création de compte est réservée aux acteurs de la planification

## Fichiers modifiés
- **Modifié :** `nuxt/pages/login/index.vue` — ajout du bloc de texte informatif

## Plan de test
- [ ] Ouvrir `/login` → deux paragraphes visibles entre "Inscription et connexion" et "Vous représentez..."
- [ ] Le lien "API" pointe vers `/exports` et est souligné
- [ ] La couleur du texte correspond au design (gris g600)

Closes #1867