### PR TITLE
Django : nettoyage de l'objet des procédures Docurba OK MEP

### DIFF
--- a/django/docurba/core/management/commands/migrate_procedure_topics.py
+++ b/django/docurba/core/management/commands/migrate_procedure_topics.py
@@ -1,0 +1,138 @@
+import csv
+import pathlib
+import re
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from docurba.core.models import Procedure, ProcedureTopic, Topic
+
+
+class Command(BaseCommand):
+    help = "Move Sudocuh Procedure.commentaire to Procedure.comment_from_sudocuh"
+
+    def add_arguments(self, parser: str) -> None:
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+        parser.add_argument("--limit", type=int, dest="limit")
+
+    def handle(self, *, wet_run: bool, limit: int, **options: dict[str, Any]) -> None:  # noqa: ARG002
+        filename = pathlib.Path(settings.EXPORTS_DIR) / "updated_procedure_topics.csv"
+        procedures_qs = (
+            Procedure.objects.filter(Q(from_sudocuh__isnull=True))
+            .exclude(Q(commentaire__isnull=True) | Q(commentaire=""))
+            .only(
+                "pk",
+                "commentaire",
+                "from_sudocuh",
+                "collectivite_porteuse",  # Mandatory because of procedureManager.get_queryset
+            )
+        )
+        topics_id_per_name = {
+            topic["display_name"]: topic["pk"]
+            for topic in Topic.objects.values("pk", "display_name")
+        }
+
+        if limit:
+            procedures_qs = procedures_qs[:limit]
+        self.stdout.write(f"Results to process: {procedures_qs.count()}")
+
+        procedures_topics_to_create = []
+        procedures_to_update = []
+        csv_output = []
+
+        for procedure in procedures_qs.iterator(1000):
+            former_commentaire = procedure.commentaire
+            other_comment = ""
+            other_comment_search = re.search(r"Autre - (.*$)", former_commentaire)
+            comment_without_other = re.sub(r"Autre - .*$", "", former_commentaire)
+            comment_without_other = re.sub(r", $", "", comment_without_other)
+            topics = []
+            has_error = False
+
+            if other_comment_search:
+                other_comment = other_comment_search.groups()[0].strip()
+
+            if comment_without_other:
+                # ", " is the way topics are concatenated today.
+                # See https://github.com/MTES-MCT/Docurba/blob/987459223d4d4e046d55d4800f8245bb5ca6b6e7/nuxt/components/Procedures/InsertForm.vue#L363
+                comment_without_other_topics = comment_without_other.split(", ")
+                try:
+                    [
+                        topics_id_per_name[topic]
+                        for topic in comment_without_other_topics
+                    ]
+                except KeyError as err:
+                    self.stderr.write(f"{err} - procedure ID {procedure.id})")
+                    has_error = True
+                    continue
+
+            if has_error:
+                continue
+
+            if other_comment:
+                procedures_topics_to_create.append(
+                    ProcedureTopic(
+                        procedure_id=procedure.id,
+                        topic_id=topics_id_per_name["Autre"],
+                        comment=other_comment,
+                    )
+                )
+                topics += [
+                    "Autre",
+                ]
+
+            if comment_without_other:
+                procedures_topics_to_create.extend(
+                    [
+                        ProcedureTopic(
+                            procedure_id=procedure.id,
+                            topic_id=topics_id_per_name[topic],
+                        )
+                        for topic in comment_without_other_topics
+                    ]
+                )
+                topics.extend(comment_without_other_topics)
+
+            procedure.commentaire = ""
+            procedures_to_update.append(procedure)
+
+            csv_output.append(
+                {
+                    "ancien_commentaire": former_commentaire,
+                    "nouveau_commentaire": procedure.commentaire,
+                    "objet_commentaire": other_comment,
+                    "procedure_id": str(procedure.pk),
+                    "objet_autre": "Autre" in topics,
+                    "objet_enr": "Zones d'accélération ENR" in topics,
+                    "objet_zan": "Trajectoire ZAN" in topics,
+                    "objet_feu_de_foret": "Feu de forêt" in topics,
+                    "objet_trait_de_cote": "Trait de côte" in topics,
+                }
+            )
+
+        if wet_run:
+            ProcedureTopic.objects.bulk_create(
+                procedures_topics_to_create, batch_size=1000
+            )
+            Procedure.objects.bulk_update(
+                procedures_to_update,
+                fields=["commentaire"],
+                batch_size=1000,
+            )
+
+        with filename.open(mode="w+", newline="") as file:
+            writer = csv.DictWriter(
+                file,
+                fieldnames=csv_output[0].keys(),
+                delimiter=";",
+            )
+            writer.writeheader()
+            writer.writerows(csv_output)
+
+        self.stdout.write(
+            f"Added procedures topics: {len(procedures_topics_to_create)}"
+        )
+        self.stdout.write(f"Updated procedures: {len(procedures_to_update)}")
+        self.stdout.write(f"Result in: {filename}")

--- a/django/tests/core/management/commands/test_migrate_procedure_topics.py
+++ b/django/tests/core/management/commands/test_migrate_procedure_topics.py
@@ -1,0 +1,129 @@
+import csv
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+from pytest_django.fixtures import SettingsWrapper
+
+from docurba.core.models import Procedure, Topic
+
+
+@pytest.mark.django_db
+class TestMigrateProceduretopics:
+    @pytest.mark.parametrize(
+        (
+            "commentaire",
+            "topic_column_name_in_csv",
+            "expected_created_topics",
+            "other_topic_comment",
+        ),
+        [
+            pytest.param("Trajectoire ZAN", ["objet_zan"], ["zan"], "", id="zan"),
+            pytest.param(
+                "Zones d'accélération ENR", ["objet_enr"], ["enr"], "", id="enr"
+            ),
+            pytest.param(
+                "Trait de côte",
+                ["objet_trait_de_cote"],
+                ["coastline"],
+                "",
+                id="trait_de_cote",
+            ),
+            pytest.param(
+                "Feu de forêt",
+                ["objet_feu_de_foret"],
+                ["forest_fire"],
+                "",
+                id="feu_de_foret",
+            ),
+            pytest.param(
+                "Feu de forêt, Trait de côte",
+                ["objet_feu_de_foret", "objet_trait_de_cote"],
+                ["forest_fire", "coastline"],
+                "",
+                id="two_topics",
+            ),
+            pytest.param(
+                "Autre - -> Ouvrir à l'urbanisation dix zones classées en XXX / Création et modification d'OAP afin d'encadrer l'urbanisation de certains secteurs en zone urbaine /Modification du plan de zonage --> Évolution du règlement écrit (clôtures, piscines, ...) ",
+                ["objet_autre"],
+                ["other"],
+                "-> Ouvrir à l'urbanisation dix zones classées en XXX / Création et modification d'OAP afin d'encadrer l'urbanisation de certains secteurs en zone urbaine /Modification du plan de zonage --> Évolution du règlement écrit (clôtures, piscines, ...)",
+                id="other_topic",
+            ),
+            pytest.param(
+                "Trajectoire ZAN, Zones d'accélération ENR, Autre - Révision générale du PLU d'Aramon",
+                ["objet_zan", "objet_enr", "objet_autre"],
+                ["zan", "enr", "other"],
+                "Révision générale du PLU d'Aramon",
+                id="zan_enr_and_other",
+            ),
+        ],
+    )
+    def test_call_command_simple_case(  # noqa: PLR0913
+        self,
+        capsys: pytest.CaptureFixture[str],
+        settings: SettingsWrapper,
+        tmp_path: Path,
+        commentaire: str,
+        topic_column_name_in_csv: list,
+        expected_created_topics: str,
+        other_topic_comment: str,
+    ) -> None:
+        settings.EXPORTS_DIR = tmp_path
+
+        procedure = Procedure.objects.create(
+            commentaire=commentaire,
+        )
+        topics = Topic.objects.filter(name__in=expected_created_topics)
+        # Assert null comments are not taken into account.
+        Procedure.objects.create(commentaire=None)
+        # Assert blank comments are not taken into account.
+        Procedure.objects.create(commentaire="")
+
+        call_command("migrate_procedure_topics", wet_run=True)
+        stdout, _ = capsys.readouterr()
+        csv_topics_column_names = [
+            "objet_enr",
+            "objet_trait_de_cote",
+            "objet_zan",
+            "objet_feu_de_foret",
+            "objet_autre",
+        ]
+        csv_topic_col_names = {
+            csv_col: "True" if csv_col in topic_column_name_in_csv else "False"
+            for csv_col in csv_topics_column_names
+        }
+
+        with Path.open(
+            Path(settings.EXPORTS_DIR) / "updated_procedure_topics.csv"
+        ) as csvfile:
+            results = list(csv.DictReader(csvfile, delimiter=";"))
+            assert len(results) == 1
+            row = results[0]
+            assert row["ancien_commentaire"] == commentaire
+            assert row["nouveau_commentaire"] == ""
+            assert row["objet_commentaire"] == other_topic_comment
+            assert [row[col] == "True" for col in topic_column_name_in_csv]
+            for col_name, col_value in csv_topic_col_names.items():
+                assert row[col_name] == col_value
+
+            assert row["procedure_id"] == str(procedure.pk)
+
+        stdout_formatted = stdout.splitlines()[:3]
+        assert stdout_formatted == [
+            "Results to process: 1",
+            f"Added procedures topics: {len(topics)}",
+            "Updated procedures: 1",
+        ]
+
+        assert Procedure.objects.filter(commentaire="").count() == 2
+        procedure.refresh_from_db()
+        assert procedure.topics.count() == topics.count()
+        assert sorted(procedure.topics.values_list("name", flat=True)) == sorted(
+            expected_created_topics
+        )
+        if other_topic_comment:
+            assert (
+                procedure.topics_through.filter(topic__name="other").get().comment
+                == other_topic_comment
+            )


### PR DESCRIPTION
Sortie du script :

```
Results to process: 3794
Added procedures topics: 3862
Updated procedures: 3776
```

18 cas d'exception :
- Des objets qui sont de la forme suivante : `Trajectoire ZAN - mise en compatibilité avec le SCOT` (ou Zones d'accélération ENR) me laissent penser qu'à un moment dans le produit on ne conservait pas le résultat du champ Objet de la même manière.
- Deux entrées champ libre sans objet autre.

Je corrigerai ces données à la main car adapter le script serait trop long.
Vu ensemble : considérer que ces éléments auraient dû être reliés à l'objet Autre donc créer une liaison Autre et ajouter le commentaire à la liaison Autre.
Résultats dans le script cohérents avec les stats par ailleurs.