### PR TITLE
Django : ajout du TextChoice CommuneType

### DIFF
--- a/django/docurba/core/enums.py
+++ b/django/docurba/core/enums.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+
+class CommuneType(models.TextChoices):
+    COM = "COM", "Commune"
+    COMD = "COMD", "Commune déléguée"
+    UNKWN = "UNKWN", "Inconnu"


### PR DESCRIPTION
C'est un prérequis pour les PR #1979 et #1982 .

Les autres TextChoices de `models.py` devraient y être déplacés également par la suite mais progressivement.