### PR TITLE
API : ajout des objets

### DIFF
--- a/django/config/urls.py
+++ b/django/config/urls.py
@@ -16,8 +16,8 @@ urlpatterns = [
         core_views.collectivite,
         name="collectivite-detail",
     ),
-    path("api/perimetres", core_views.api_perimetres),
-    path("api/communes", core_views.api_communes),
+    path("api/perimetres", core_views.api_perimetres, name="api_perimetres"),
+    path("api/communes", core_views.api_communes, name="api_communes"),
     path("api/scots", core_views.api_scots, name="api_scots"),
     # URLs Nuxt globales
     path("", nuxt_proxy, {"path": ""}),

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -252,6 +252,14 @@ EVENT_CATEGORY_BY_DOC_TYPE |= dict.fromkeys(
     PLU_LIKE, EVENT_CATEGORY_BY_DOC_TYPE[TypeDocument.PLU]
 )
 
+# Reverse of EVENT_CATEGORY_BY_DOC_TYPE keeping the same first-level keys.
+EVENT_TYPE_BY_EVENT_CATEGORY = {}
+for doc_type, types in EVENT_CATEGORY_BY_DOC_TYPE.items():
+    for name, category in types.items():
+        EVENT_TYPE_BY_EVENT_CATEGORY.setdefault(doc_type, {}).setdefault(
+            category, []
+        ).append(name)
+
 
 class ProcedureStatusChoices(models.TextChoices):
     ANNULE = "annule", "Annulé"

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -8,6 +8,8 @@ from typing import Self
 
 from django.contrib.postgres.functions import RandomUUID, TransactionNow
 from django.db import connection, models
+from django.db.models import Value
+from django.db.models.aggregates import StringAgg
 from django.db.models.constraints import UniqueConstraint
 from django.db.models.functions import Now
 from django.urls import reverse
@@ -309,6 +311,15 @@ class ProcedureQuerySet(models.QuerySet):
     def without_adhesions_count(self) -> Self:
         self.query.annotations.pop("communes_adherentes__count")
         return self
+
+    def with_concatenated_topics_as_string(self) -> Self:
+        return self.annotate(
+            concatenated_topics_as_string=StringAgg(
+                "topics__display_name",
+                delimiter=Value(","),
+                order_by="topics__display_name",
+            ),
+        )
 
 
 class ProcedureManager(models.Manager):
@@ -684,6 +695,7 @@ class CollectiviteQuerySet(models.QuerySet):
                     "procedure_set",
                     Procedure.objects.defer("current_perimetre", "initial_perimetre")
                     .with_events(avant=avant)
+                    .with_concatenated_topics_as_string()
                     .without_adhesions_count()
                     .order_by("created_at")
                     .filter(

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -791,6 +791,7 @@ class CommuneQuerySet(models.QuerySet):
     ) -> Self:
         procedures_principales = (
             Procedure.objects.defer("current_perimetre", "initial_perimetre")
+            .with_concatenated_topics_as_string()
             .with_events(avant=avant)
             .filter(parente=None, archived=False)
         )

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -310,6 +310,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
             "pa_annee_approbation",
             "pa_date_fin_echeance",
             "pa_nombre_communes",
+            "pa_objets",
             # En cours
             "pc_id",
             "pc_nom_schema",
@@ -320,6 +321,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
             "pc_date_prescription",
             "pc_date_arret_projet",
             "pc_nombre_communes",
+            "pc_objets",
         ],
     )
 
@@ -353,6 +355,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
                 "pa_annee_approbation": scot_opposable.date_approbation.year,
                 "pa_date_fin_echeance": scot_opposable.date_fin_echeance,
                 "pa_nombre_communes": len(scot_opposable.communes),
+                "pa_objets": scot_opposable.concatenated_topics_as_string,
             }
 
         champs_en_cours = {}
@@ -367,6 +370,7 @@ def api_scots(request: HttpRequest) -> HttpResponse:
                 "pc_date_prescription": scot_en_cours.date_prescription,
                 "pc_date_arret_projet": scot_en_cours.date_arret_projet,
                 "pc_nombre_communes": len(scot_en_cours.communes),
+                "pc_objets": scot_en_cours.concatenated_topics_as_string,
             }
 
         return champs_groupement | champs_opposable | champs_en_cours

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -134,6 +134,7 @@ def api_communes(request: HttpRequest) -> HttpResponse:
             "pc_nom_sst",
             "pc_cout_sst_ht",
             "pc_cout_sst_ttc",
+            "pc_objets",
             # Approuvée
             "pa_docurba_id",
             "pa_num_procedure_sudocuh",
@@ -157,6 +158,7 @@ def api_communes(request: HttpRequest) -> HttpResponse:
             "pa_nom_sst",
             "pa_cout_sst_ht",
             "pa_cout_sst_ttc",
+            "pa_objets",
         ],
     )
 
@@ -225,6 +227,7 @@ def api_communes(request: HttpRequest) -> HttpResponse:
                 and plan_en_cours.maitrise_d_oeuvre["coutplanht"],
                 "pc_cout_sst_ttc": plan_en_cours.maitrise_d_oeuvre
                 and plan_en_cours.maitrise_d_oeuvre["coutplanttc"],
+                "pc_objets": plan_en_cours.concatenated_topics_as_string,
             }
 
         champs_opposable = {}
@@ -256,6 +259,7 @@ def api_communes(request: HttpRequest) -> HttpResponse:
                 and plan_opposable.maitrise_d_oeuvre["coutplanht"],
                 "pa_cout_sst_ttc": plan_opposable.maitrise_d_oeuvre
                 and plan_opposable.maitrise_d_oeuvre["coutplanttc"],
+                "pa_objets": plan_opposable.concatenated_topics_as_string,
             }
         return (
             champs_commune

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -40,6 +40,7 @@ ignore = [
     "D10",    # Missing docstring
     "E501",   # Line too long
     "TD",     # Todos
+    "PLR0913", # Too many arguments in function definition
     # "ERA001", # Commented out code
 ]
 [tool.ruff.lint.per-file-ignores]

--- a/django/tests/core/factories.py
+++ b/django/tests/core/factories.py
@@ -6,6 +6,7 @@ import factory.fuzzy
 
 from docurba.core.enums import CommuneType
 from docurba.core.models import (
+    EVENT_TYPE_BY_EVENT_CATEGORY,
     Collectivite,
     Commune,
     CommuneProcedure,
@@ -171,6 +172,19 @@ class ProcedureFactory(factory.django.DjangoModelFactory):
                 procedure=self,
                 commune=commune,
             )
+
+    @factory.post_generation
+    def with_event(self, create: bool, extracted: bool, **extra: dict) -> None:  # noqa: FBT001
+        if not create or not extracted:
+            return
+
+        event_type = "Prescription"
+        if extra.get("category"):
+            event_type = EVENT_TYPE_BY_EVENT_CATEGORY[self.doc_type][
+                extra.pop("category")
+            ][0]
+
+        EventFactory(procedure=self, type=event_type, **extra)
 
 
 class CommuneProcedureFactory(factory.django.DjangoModelFactory):

--- a/django/tests/core/management/commands/test_migrate_procedure_topics.py
+++ b/django/tests/core/management/commands/test_migrate_procedure_topics.py
@@ -59,7 +59,7 @@ class TestMigrateProceduretopics:
             ),
         ],
     )
-    def test_call_command_simple_case(  # noqa: PLR0913
+    def test_call_command_simple_case(
         self,
         capsys: pytest.CaptureFixture[str],
         settings: SettingsWrapper,

--- a/django/tests/core/test_models.py
+++ b/django/tests/core/test_models.py
@@ -15,6 +15,7 @@ from docurba.core.models import (
     Event,
     EventCategory,
     Procedure,
+    Topic,
     TypeDocument,
     ViewCommuneAdhesionsDeep,
 )
@@ -28,6 +29,22 @@ from tests.core.factories import (
 class TestCollectivite:
     def test_code_insee(self) -> None:
         assert Commune(id="12345_COM").code_insee == "12345"
+
+
+class TestProcedureQuerySet:
+    @pytest.mark.django_db
+    def test_with_concatenated_topics_as_string(
+        self, django_assert_num_queries: DjangoAssertNumQueries
+    ) -> None:
+        topics = Topic.objects.filter(name__in=["zan", "forest_fire"])
+        procedure = ProcedureFactory()
+        procedure.topics.add(*topics)
+        with django_assert_num_queries(1):
+            procedure = Procedure.objects.with_concatenated_topics_as_string().get(
+                pk=procedure.pk
+            )
+        assert hasattr(procedure, "concatenated_topics_as_string")
+        assert procedure.concatenated_topics_as_string == "Feu de forêt,Trajectoire ZAN"
 
 
 class TestProcedureCommunesCounts:

--- a/django/tests/core/test_views.py
+++ b/django/tests/core/test_views.py
@@ -6,7 +6,13 @@ from django.test import Client
 from django.urls import reverse
 from pytest_django import DjangoAssertNumQueries
 
-from docurba.core.models import TypeDocument
+from docurba.core.models import (
+    EventCategory,
+    Procedure,
+    TypeCollectivite,
+    TypeDocument,
+    ViewCommuneAdhesionsDeep,
+)
 from tests.core.factories import (
     CollectiviteFactory,
     CommuneFactory,
@@ -259,36 +265,113 @@ class TestAPICommunes:
 
 class TestAPIScots:
     @pytest.mark.django_db
-    def test_format_csv(
-        self, client: Client, django_assert_num_queries: DjangoAssertNumQueries
+    @pytest.mark.parametrize(
+        (
+            "nb_communes",
+            "event_category",
+            "dict_attendu_dans_resultat",
+        ),
+        [
+            pytest.param(
+                3,
+                "Délibération d'approbation",
+                {
+                    "pa_nombre_communes": "3",
+                    "pa_annee_approbation": "2024",
+                    "pa_date_approbation": "2024-12-01",
+                    "pa_scot_interdepartement": "False",
+                },
+                id="scot_approuve_plusieurs_communes",
+            ),
+            pytest.param(
+                3,
+                "Publication de périmètre",
+                {
+                    "pc_nombre_communes": "3",
+                    "pc_date_publication_perimetre": "2024-12-01",
+                    "pc_scot_interdepartement": "False",
+                    "pc_proc_elaboration_revision": "Élaboration",
+                },
+                id="scot_en_cours_plusieurs_communes",
+            ),
+            pytest.param(
+                0,
+                "Publication de périmètre",
+                {
+                    "pc_nombre_communes": "0",
+                    "pc_date_publication_perimetre": "2024-12-01",
+                    "pc_scot_interdepartement": "False",
+                    "pc_proc_elaboration_revision": "Élaboration",
+                },
+                id="scot_en_cours_sans_commune",
+            ),
+        ],
+    )
+    def test_scot_cas_differents(
+        self,
+        client: Client,
+        django_assert_num_queries: DjangoAssertNumQueries,
+        nb_communes: int,
+        event_category: dict[str, EventCategory],
+        dict_attendu_dans_resultat: dict[str, str],
     ) -> None:
-        event = EventFactory(
-            type="Publication de périmètre", procedure__doc_type=TypeDocument.SCOT
+        perimetre_initial = CommuneFactory.create_batch(
+            nb_communes, departement__code_insee="13"
         )
-        collectivite = event.procedure.collectivite_porteuse
+        collectivite_porteuse = CollectiviteFactory(type=TypeCollectivite.CC)
+        collectivite_porteuse.collectivites_adherentes.add(*perimetre_initial)
+        ViewCommuneAdhesionsDeep._refresh_materialized_view()  # noqa: SLF001
 
-        with django_assert_num_queries(4):
+        event = EventFactory(
+            type=event_category,
+            date_evenement="2024-12-01",
+            procedure__doc_type=TypeDocument.SCOT,
+            procedure__with_perimetre=perimetre_initial,
+            procedure__collectivite_porteuse=collectivite_porteuse,
+        )
+        # .with_events() is required to call scot.statut
+        scot = Procedure.objects.with_events().get(pk=event.procedure_id)
+
+        with django_assert_num_queries(6 if nb_communes else 4):
             response = client.get(reverse("api_scots"))
-
-        assert response.status_code == 200
-        assert response["content-type"] == "text/csv;charset=utf-8"
-
-        reader = DictReader(response.content.decode().splitlines())
-
-        assert list(reader) == [
-            {
-                "annee_cog": "2024",
-                # Collectivité
-                "scot_code_region": collectivite.departement.region.code_insee,
-                "scot_libelle_region": collectivite.departement.region.nom,
-                "scot_code_departement": collectivite.departement.code_insee,
-                "scot_lib_departement": collectivite.departement.nom,
-                "scot_codecollectivite": collectivite.code_insee,
-                "scot_code_type_collectivite": collectivite.type,
-                "scot_nom_collectivite": collectivite.nom,
-                # Approuvée
-                "pa_id": "",
-                "pa_nom_schema": "",
+        result = list(DictReader(response.content.decode().splitlines()))
+        resultat_par_defaut = {
+            "annee_cog": "2024",
+            # Collectivité
+            "scot_code_region": collectivite_porteuse.departement.region.code_insee,
+            "scot_libelle_region": collectivite_porteuse.departement.region.nom,
+            "scot_code_departement": collectivite_porteuse.departement.code_insee,
+            "scot_lib_departement": collectivite_porteuse.departement.nom,
+            "scot_codecollectivite": collectivite_porteuse.code_insee,
+            "scot_code_type_collectivite": collectivite_porteuse.type.value,
+            "scot_nom_collectivite": scot.collectivite_porteuse.nom,
+            # Approuvée
+            "pa_id": "",
+            "pa_nom_schema": "",
+            "pa_noserie_procedure": "",
+            "pa_scot_interdepartement": "",
+            "pa_date_publication_perimetre": "",
+            "pa_date_prescription": "",
+            "pa_date_arret_projet": "",
+            "pa_date_approbation": "",
+            "pa_annee_approbation": "",
+            "pa_date_fin_echeance": "",
+            "pa_nombre_communes": "",
+            # En cours
+            "pc_id": "",
+            "pc_nom_schema": "",
+            "pc_noserie_procedure": "",
+            "pc_proc_elaboration_revision": "",
+            "pc_scot_interdepartement": "",
+            "pc_date_publication_perimetre": "",
+            "pc_date_prescription": "",
+            "pc_date_arret_projet": "",
+            "pc_nombre_communes": "",
+        }
+        if scot.statut == EventCategory.APPROUVE:
+            resultat_par_defaut = resultat_par_defaut | {
+                "pa_id": str(scot.id),
+                "pa_nom_schema": str(scot.name),
                 "pa_noserie_procedure": "",
                 "pa_scot_interdepartement": "",
                 "pa_date_publication_perimetre": "",
@@ -298,18 +381,21 @@ class TestAPIScots:
                 "pa_annee_approbation": "",
                 "pa_date_fin_echeance": "",
                 "pa_nombre_communes": "",
-                # En cours
-                "pc_id": str(event.procedure.id),
-                "pc_nom_schema": event.procedure.name,
+            }
+        elif scot.statut == EventCategory.PUBLICATION_PERIMETRE:
+            resultat_par_defaut = resultat_par_defaut | {
+                "pc_id": str(scot.id),
+                "pc_nom_schema": str(scot.name),
                 "pc_noserie_procedure": "",
                 "pc_proc_elaboration_revision": "Élaboration",
                 "pc_scot_interdepartement": "False",
                 "pc_date_publication_perimetre": str(event.date_evenement),
                 "pc_date_prescription": "",
                 "pc_date_arret_projet": "",
-                "pc_nombre_communes": "0",
+                "pc_nombre_communes": "",
             }
-        ]
+        expected_result = resultat_par_defaut | dict_attendu_dans_resultat
+        assert result[0] == expected_result
 
     @pytest.mark.parametrize(
         ("is_filtering", "expected_lignes"), [(False, 2), (True, 1)]

--- a/django/tests/core/test_views.py
+++ b/django/tests/core/test_views.py
@@ -307,15 +307,9 @@ class TestAPICommunes:
             doc_type=TypeDocument.PLU,
             with_perimetre=[CommuneFactory()],
             collectivite_porteuse=CollectiviteFactory(),
+            with_event=True,
+            with_event__category=procedure_status,
         )
-        match procedure_status:
-            case EventCategory.PUBLICATION_PERIMETRE:
-                EventFactory(type="Publication de périmètre", procedure=procedure)
-            case EventCategory.APPROUVE:
-                EventFactory(
-                    type="Délibération d'approbation du municipal ou communautaire",
-                    procedure=procedure,
-                )
         if procedure_topics_to_add:
             topics = Topic.objects.filter(name__in=procedure_topics_to_add)
             procedure.topics.add(*topics)
@@ -507,15 +501,9 @@ class TestAPIScots:
         procedure = ProcedureFactory(
             doc_type=TypeDocument.SCOT,
             with_perimetre=[CommuneFactory()],
+            with_event=True,
+            with_event__category=procedure_status,
         )
-        match procedure_status:
-            case EventCategory.PUBLICATION_PERIMETRE:
-                EventFactory(type="Publication de périmètre", procedure=procedure)
-            case EventCategory.APPROUVE:
-                EventFactory(
-                    type="Retrait de l'annulation totale",
-                    procedure=procedure,
-                )
 
         if procedure_topics_to_add:
             topics = Topic.objects.filter(name__in=procedure_topics_to_add)

--- a/django/tests/core/test_views.py
+++ b/django/tests/core/test_views.py
@@ -9,6 +9,7 @@ from pytest_django import DjangoAssertNumQueries
 from docurba.core.models import (
     EventCategory,
     Procedure,
+    Topic,
     TypeCollectivite,
     TypeDocument,
     ViewCommuneAdhesionsDeep,
@@ -357,6 +358,7 @@ class TestAPIScots:
             "pa_annee_approbation": "",
             "pa_date_fin_echeance": "",
             "pa_nombre_communes": "",
+            "pa_objets": "",
             # En cours
             "pc_id": "",
             "pc_nom_schema": "",
@@ -367,6 +369,7 @@ class TestAPIScots:
             "pc_date_prescription": "",
             "pc_date_arret_projet": "",
             "pc_nombre_communes": "",
+            "pc_objets": "",
         }
         if scot.statut == EventCategory.APPROUVE:
             resultat_par_defaut = resultat_par_defaut | {
@@ -396,6 +399,70 @@ class TestAPIScots:
             }
         expected_result = resultat_par_defaut | dict_attendu_dans_resultat
         assert result[0] == expected_result
+
+    @pytest.mark.parametrize(
+        ("procedure_status", "expected_filled_key", "expected_empty_key"),
+        [
+            pytest.param(
+                EventCategory.PUBLICATION_PERIMETRE,
+                "pc_objets",
+                "pa_objets",
+                id="ongoing_procedure",
+            ),
+            pytest.param(
+                EventCategory.APPROUVE,
+                "pa_objets",
+                "pc_objets",
+                id="approved_procedure",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("procedure_topics_to_add", "expected_result"),
+        [
+            pytest.param("", "", id="no_topic"),
+            pytest.param(["zan"], "Trajectoire ZAN", id="one_topic"),
+            pytest.param(
+                ["zan", "forest_fire"],
+                "Feu de forêt,Trajectoire ZAN",
+                id="several_topics",
+            ),
+        ],
+    )
+    @pytest.mark.django_db
+    def test_with_topics(  # noqa: PLR0913
+        self,
+        procedure_status: EventCategory,
+        expected_filled_key: str,
+        expected_empty_key: str,
+        procedure_topics_to_add: str,
+        expected_result: str,
+        client: Client,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        procedure = ProcedureFactory(
+            doc_type=TypeDocument.SCOT,
+            with_perimetre=[CommuneFactory()],
+        )
+        match procedure_status:
+            case EventCategory.PUBLICATION_PERIMETRE:
+                EventFactory(type="Publication de périmètre", procedure=procedure)
+            case EventCategory.APPROUVE:
+                EventFactory(
+                    type="Retrait de l'annulation totale",
+                    procedure=procedure,
+                )
+
+        if procedure_topics_to_add:
+            topics = Topic.objects.filter(name__in=procedure_topics_to_add)
+            procedure.topics.add(*topics)
+
+        with django_assert_num_queries(6):
+            response = client.get(reverse("api_scots"))
+
+        results = list(DictReader(response.content.decode().splitlines()))
+        assert results[0][expected_filled_key] == expected_result
+        assert results[0][expected_empty_key] == ""
 
     @pytest.mark.parametrize(
         ("is_filtering", "expected_lignes"), [(False, 2), (True, 1)]

--- a/django/tests/core/test_views.py
+++ b/django/tests/core/test_views.py
@@ -263,6 +263,70 @@ class TestAPICommunes:
         reader = DictReader(response.content.decode().splitlines())
         assert [cp["pc_type_document"] for cp in reader] == ["PLU", "PLU"]
 
+    @pytest.mark.parametrize(
+        ("procedure_status", "expected_filled_key", "expected_empty_key"),
+        [
+            pytest.param(
+                EventCategory.PUBLICATION_PERIMETRE,
+                "pc_objets",
+                "pa_objets",
+                id="ongoing_procedure",
+            ),
+            pytest.param(
+                EventCategory.APPROUVE,
+                "pa_objets",
+                "pc_objets",
+                id="approved_procedure",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("procedure_topics_to_add", "expected_result"),
+        [
+            pytest.param("", "", id="no_topic"),
+            pytest.param(["zan"], "Trajectoire ZAN", id="one_topic"),
+            pytest.param(
+                ["zan", "forest_fire"],
+                "Feu de forêt,Trajectoire ZAN",
+                id="several_topics",
+            ),
+        ],
+    )
+    @pytest.mark.django_db
+    def test_with_topics(
+        self,
+        procedure_status: EventCategory,
+        expected_filled_key: str,
+        expected_empty_key: str,
+        procedure_topics_to_add: str,
+        expected_result: str,
+        client: Client,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        procedure = ProcedureFactory(
+            doc_type=TypeDocument.PLU,
+            with_perimetre=[CommuneFactory()],
+            collectivite_porteuse=CollectiviteFactory(),
+        )
+        match procedure_status:
+            case EventCategory.PUBLICATION_PERIMETRE:
+                EventFactory(type="Publication de périmètre", procedure=procedure)
+            case EventCategory.APPROUVE:
+                EventFactory(
+                    type="Délibération d'approbation du municipal ou communautaire",
+                    procedure=procedure,
+                )
+        if procedure_topics_to_add:
+            topics = Topic.objects.filter(name__in=procedure_topics_to_add)
+            procedure.topics.add(*topics)
+
+        with django_assert_num_queries(4):
+            response = client.get(reverse("api_communes"))
+
+        results = list(DictReader(response.content.decode().splitlines()))
+        assert results[0][expected_filled_key] == expected_result
+        assert results[0][expected_empty_key] == ""
+
 
 class TestAPIScots:
     @pytest.mark.django_db
@@ -430,7 +494,7 @@ class TestAPIScots:
         ],
     )
     @pytest.mark.django_db
-    def test_with_topics(  # noqa: PLR0913
+    def test_with_topics(
         self,
         procedure_status: EventCategory,
         expected_filled_key: str,

--- a/nuxt/content/Dev/API/communes.md
+++ b/nuxt/content/Dev/API/communes.md
@@ -87,6 +87,7 @@ Pour le plan en cours :
 - `pc_nom_sst` : Nom du prestataire externe
 - `pc_cout_sst_ht` : Coût HT
 - `pc_cout_sst_ttc` : Coût TTC
+- `pc_objets` : Objets de la procédure séparés par des virgules
 
 <br>
 Pour le plan opposable :
@@ -113,6 +114,7 @@ Pour le plan opposable :
 - `pa_nom_sst` : Nom du prestataire externe
 - `pa_cout_sst_ht` : Coût HT
 - `pa_cout_sst_ttc` : Coût TTC
+- `pa_objets` : Objets de la procédure séparés par des virgules
 
 <br>
 Toutes les dates sont au format ISO 8601.

--- a/nuxt/content/Dev/API/scots.md
+++ b/nuxt/content/Dev/API/scots.md
@@ -58,6 +58,7 @@ Pour le SCoT opposable :
 - `pa_annee_approbation` : Année d'approbation
 - `pa_date_fin_echeance` : Date de fin d'échéance
 - `pa_nombre_communes` : Nombre de communes dans le périmètre de la procédure
+- `pa_objets` : Objets de la procédure séparés par des virgules
 
 <br>
 Pour le SCoT en cours :
@@ -71,6 +72,7 @@ Pour le SCoT en cours :
 - `pc_date_prescription` : Date de prescription
 - `pc_date_arret_projet` : Date d'arrêt de projet
 - `pc_nombre_communes` : Nombre de communes dans le périmètre de la procédure
+- `pc_objets` : Objets de la procédure séparés par des virgules
 
 <br>
 Toutes les dates sont au format ISO 8601.


### PR DESCRIPTION
Je conseille une relecture _commit_ par _commit_.

# Quoi 

Ajout des clés `pa_objets` et `pc_objets` aux API `scots` et `communes` pour exposer la liste des objets des procédures. Cette liste est une chaîne de caractères séparée par des virgules.

# Comment

Modification des tests de l'API scots pour les rendre plus robustes.
Ajout d'une annotation.
Ajout d'un test à l'API communes et ajout d'un test unitaire pour l'annotation.
Ajout des clés.
Mise à jour de la documentation (qui est dans Nuxt pour le moment car les API étaient d'abord gérées dans Nuxt).
Ajout de `EVENT_TYPE_BY_EVENT_CATEGORY` et ajout de `ProcedureFactory.with_event` : cela permet de passer en paramètre de la factory le statut de procédure souhaité en attendant de remettre à plat le calcul du statut et la classification des événements. À discuter ensemble si tu veux @pitiscarf . 

# Pourquoi

Afin de suivre l'évolution des ZAN, le bureau a besoin de récupérer la liste des procédures ZAN.

# Notes pour le bureau

<img width="920" height="772" alt="image" src="https://github.com/user-attachments/assets/4df11104-bf35-47e4-9443-720d4dad368f" />
Données > plus de filtres > filtres standards > nom de champ : "pc_objets" > Condition : "contient" > Valeur : "Trajectoire ZAN"
