### PR TITLE
Loi Huwart : ajout d'un label sur les procédures datées d'avant la loi

### DIFF
--- a/nuxt/components/Dashboard/DUProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUProcedureItem.vue
@@ -24,7 +24,11 @@
           Type de procédure
         </div>
         <div>
-          {{ procedure.type }}
+          {{ procedure.type }}{{
+            procedure.type === 'Modification' && procedure.started_before_huwart_law
+              ? ' (antérieure à la loi Huwart)'
+              : ''
+          }}
         </div>
       </v-col>
       <v-col>

--- a/nuxt/components/Dashboard/DUSubProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUSubProcedureItem.vue
@@ -14,7 +14,11 @@
           Type de procédure
         </div>
         <div>
-          {{ procedure.type }}
+          {{ procedure.type }}{{
+            procedure.type === 'Modification' && procedure.started_before_huwart_law
+              ? ' (antérieure à la loi Huwart)'
+              : ''
+          }}
         </div>
       </v-col>
       <v-col>


### PR DESCRIPTION
<img width="515" height="167" alt="before-huwart-law-label" src="https://github.com/user-attachments/assets/5aeb82f8-9c44-4576-bbc9-3dcd854ebd57" />

|

<img width="743" height="461" alt="before-huwart-law-label-2" src="https://github.com/user-attachments/assets/dfb7bcc7-591b-4842-9e08-c75d3f4ba8ca" />

