### PR TITLE
Afficher si la procédure a été lancée avant la loi Huwart dans l'admin Django

### DIFF
--- a/django/docurba/core/admin.py
+++ b/django/docurba/core/admin.py
@@ -122,12 +122,14 @@ class ProcedureAdmin(admin.ModelAdmin):
         "current_perimetre",
         "is_principale",
         "archived",
+        "started_before_huwart_law",
     )
     autocomplete_fields = ("collectivite_porteuse",)
     list_filter = (
         ("parente", admin.EmptyFieldListFilter),
         ("name", admin.EmptyFieldListFilter),
         "doc_type",
+        "started_before_huwart_law",
         CollectiviteTypeFilter,
         TopicsFilter,
     )

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -372,7 +372,9 @@ class Procedure(models.Model):
     current_perimetre = models.JSONField(null=True)
 
     last_updated_by = models.ForeignKey("users.Profile", models.DO_NOTHING, null=True)
-    started_before_huwart_law = models.BooleanField(db_default=False)
+    started_before_huwart_law = models.BooleanField(
+        db_default=False, verbose_name="lancée avant la loi Huwart"
+    )
 
     # Denormalized information used only by Nuxt. See self.statut for the Django logic.
     status = models.CharField(choices=ProcedureStatusChoices, blank=True, null=True)  # noqa: DJ001

--- a/django/tests/core/test_admin.py
+++ b/django/tests/core/test_admin.py
@@ -50,3 +50,17 @@ class TestProcedureList:
         response = admin_client.get(reverse("admin:core_procedure_changelist"))
         assertContains(response, procedure_polem.pk)
         assertContains(response, procedure_cc.pk)
+
+    def test_huwart_law_filter(self, admin_client: Client) -> None:
+        huwart = ProcedureFactory(started_before_huwart_law=True)
+        not_huwart = ProcedureFactory(started_before_huwart_law=False)
+
+        response = admin_client.get(
+            f"{reverse('admin:core_procedure_changelist')}?started_before_huwart_law__exact=1"
+        )
+        assertNotContains(response, not_huwart.pk)
+        assertContains(response, huwart.pk)
+
+        response = admin_client.get(reverse("admin:core_procedure_changelist"))
+        assertContains(response, not_huwart.pk)
+        assertContains(response, huwart.pk)


### PR DESCRIPTION
Liste des procédures : ajout d'un filtre.
Page de la procédure : ajout de la valeur (non modifiable pour l'instant) 

<img width="1786" height="846" alt="image" src="https://github.com/user-attachments/assets/ea0f2e62-fe5d-4c47-8580-9251161e742b" />
