### PR TITLE
Lancer l'event 'land' depuis le client plutôt que le serveur

### DIFF
--- a/nuxt/middleware/analytics.js
+++ b/nuxt/middleware/analytics.js
@@ -1,10 +1,16 @@
 export default ({ $supabase, $analytics, route, app }) => {
+  // Skipping the first page event trigger because the user is not available
+  // during server rendering
+  if (!process.client) {
+    return
+  }
+
   const { resolved } = app.router.resolve(route.path)
 
   if (resolved.matched.length > 0) {
     $analytics({
       category: 'page view',
-      name: process.client ? 'navigate' : 'land',
+      name: 'navigate',
       value: route.path
     })
   }

--- a/nuxt/plugins/analytics.js
+++ b/nuxt/plugins/analytics.js
@@ -58,4 +58,19 @@ export default ({ $supabase, $user, $isDev, app }, inject) => {
   }
 
   inject('analytics', sendEvent)
+
+  if (!process.client) {
+    return
+  }
+
+  // Trigger an analytics page view when first loading the app on the client
+  const { resolved } = app.router.resolve(app.router.currentRoute.path)
+
+  if (resolved.matched.length > 0) {
+    sendEvent({
+      category: 'page view',
+      name: 'land',
+      value: app.router.currentRoute.path
+    })
+  }
 }


### PR DESCRIPTION
Le souci réside dans le fait que l'authentification supabase n'est pas accessible côté SSR.
L'event `land` est envoyé depuis le middleware analytics branché sur le router. Celui-ci est appelé côté client durant la navigation mais côté serveur durant le premier chargement du site.

Il existe un module `@supabase/ssr` qui théoriquement rend accessible l'authentification côté SSR mais il m'a été impossible de l'installer à cause de soucis de compatibilité.

Pour contourner le souci, cette PR retire l'appel côté SSR et le remplace par un appel lors de l'instanciation du plugin analytics côté client.