### PR TITLE
Filtrer les types de DU disponibles en fonction du nombre de communes sélectionnées lors de la création d'une procédure

### DIFF
--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -206,7 +206,6 @@ export default {
       topicOtherComment: '',
       typeDu: '',
       nameComplement: '',
-      typesDu: ['CC', 'PLU', 'PLUi', 'PLUiH', 'PLUiM', 'PLUiHM', 'SCOT'],
       perimetre: null,
       icons: { mdiInformationOutline, mdiOpenInNew }
     }
@@ -214,6 +213,18 @@ export default {
   computed: {
     typeCompetence () {
       return this.typeDu === 'SCOT' ? 'competenceSCOT' : 'competencePLU'
+    },
+    typesDu () {
+      const multipleCommunesDUTypes = ['PLUi', 'PLUiH', 'PLUiM', 'PLUiHM', 'SCOT']
+      const singleCommuneDUTypes = ['CC', 'PLU']
+
+      if (!this.perimetre || !this.perimetre.length) {
+        return [...singleCommuneDUTypes, ...multipleCommunesDUTypes]
+      }
+
+      return this.perimetre.length === 1
+        ? singleCommuneDUTypes
+        : multipleCommunesDUTypes
     },
     collectivitePorteuseCode () {
       if (this.collectivite[this.typeCompetence]) {
@@ -255,6 +266,16 @@ export default {
     },
     topicOtherCommentSelected () {
       return this.topics.some(e => e.text === 'Autre')
+    }
+  },
+  watch: {
+    typesDu (newTypesDu) {
+      if (
+        this.typeDu &&
+        !newTypesDu.includes(this.typeDu)
+      ) {
+        this.typeDu = ''
+      }
     }
   },
   async mounted () {


### PR DESCRIPTION
closes #1986

Aucune commune sélectionnée :
<img width="862" height="479" alt="du-type-0" src="https://github.com/user-attachments/assets/bcc88c56-4880-4602-abb5-c59502591eb9" />
Une commune sélectionnée :
<img width="860" height="475" alt="du-type-1" src="https://github.com/user-attachments/assets/8aa9b2d5-d7c3-4243-8049-35e92f1bfd44" />
Plusieurs communes sélectionnées :
<img width="861" height="477" alt="du-type-2" src="https://github.com/user-attachments/assets/7645f8be-5bbf-44f2-8486-f120a04815df" />

