### PR TITLE
Corriger l'erreur de chargement du formulaire de création de procédure secondaire

### DIFF
--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -312,6 +312,9 @@ export default {
         // eslint-disable-next-line no-console
         console.log('error getProcedures', error)
       }
+      if (procedures.length === 0) {
+        return []
+      }
 
       const collectiviteCodes = new Set(procedures.flatMap(p => [
         p.collectivite_porteuse_id,
@@ -334,7 +337,7 @@ export default {
           } else { return c.code === p.collectivite_porteuse_id }
         })
 
-        if (comd) {
+        if (collectivite && comd) {
           collectivite.intitule += ' COMD'
         }
 
@@ -346,7 +349,9 @@ export default {
       })
 
       if (this.collectivite.type !== 'COM') {
-        return enrichedProcedures.filter(e => e.current_perimetre.length > 1)
+        return enrichedProcedures.filter(e =>
+          e.current_perimetre && e.current_perimetre.length > 1
+        )
       } else {
         return enrichedProcedures
       }

--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -164,7 +164,7 @@
         <p class="text-h6">
           Pas de procédure principale
         </p>
-        Aucune procédure principale n’a été trouvée pour la collectivité. Une procédure secondaire doit être attachée à une procédure principale.
+        Aucune procédure principale opposable n’a été trouvée pour la collectivité. Une procédure secondaire doit être attachée à une procédure principale opposable.
       </v-col>
     </v-row>
   </v-container>


### PR DESCRIPTION
closes #1090

Lors du chargement de la page du formulaire de creation de procédure secondaire on essayait d'accéder à des propriétés de variables `undefined`.
- Lorsqu'on ne trouvait pas de procédure durant le `collectivites.find()` on essayait ensuite d'accéder à `procedure.intitule`
- Lorsque le `current_perimetre` d'une procédure était `undefined` on essayait d'accéder à `current_perimetre.length`