### PR TITLE
Dependabot : mise à jour quotidienne

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,4 @@ updates:
     cooldown:
       default-days: 7
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Paris"
+      interval: "daily"


### PR DESCRIPTION
We already wait for 7 days.
See https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
