### PR TITLE
Rendre la page /documents/projet-<id>/pac accessible publiquement

### DIFF
--- a/nuxt/pages/documents/_githubRef/pac.vue
+++ b/nuxt/pages/documents/_githubRef/pac.vue
@@ -100,9 +100,6 @@ export default {
   },
   async mounted () {
     if (this.gitRef.includes('projet-')) {
-      // Role verification
-      await this.$refRole(this.gitRef, ['read', 'write'], '/')
-
       const projectId = this.gitRef.replace('projet-', '')
 
       const { data: projects } = await this.$supabase.from('projects').select('*').eq('id', projectId)


### PR DESCRIPTION
closes #1280

La page `/documents/projet-<id>/pac` est en lecture seule.

Pour les ddts, la page en écriture est `/trames/projet-<id>`.
Si une personne n'ayant pas d'accès en écriture essaie d'y accéder, elle sera redirigée sur `/documents/projet-<id>/pac` (c'était déjà le cas, mais une fois arrivée sur cette seconde page, il y avait un nouveau check qui redirigeait sur la page d'accueil si la personne n'avait pas de droits explicites en lecture).