### PR TITLE
Nginx reverse proxy integration

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -12,7 +12,6 @@ jobs:
       DJANGO_SETTINGS_MODULE: config.settings.test
       TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/test_docurba
       SECRET_KEY: test_secret_key
-      UPSTREAM_NUXT: http://localhost:3000
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -155,7 +155,6 @@ jobs:
         echo "::add-mask::${django_secret_key}";
         scalingo --app ${SCALINGO_DJANGO_APP_NAME} integration-link-manual-review-app ${{ github.event.number }}
         scalingo --app "${DJANGO_REVIEW_APP_NAME}" env-set \
-         UPSTREAM_NUXT="${NUXT_URL}" \
          DATABASE_URL="${DATABASE_URL}" \
          NUXT3_API_URL="${NUXT3_URL}" \
          SECRET_KEY="${django_secret_key}"

--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -17,6 +17,7 @@ env:
   PR_ID: ${{ github.event.number }}
   SCALINGO_DJANGO_APP_NAME: docurba-django-demo
   SCALINGO_NUXT_APP_NAME: docurba-nuxt-demo
+  SCALINGO_REVPROXY_APP_NAME: docurba-revproxy-demo
   NUXT3_REPO_HTTPS: https://github.com/betagouv/docurba-nuxt3/
   NUXT3_BRANCH: main
 
@@ -42,6 +43,8 @@ jobs:
         echo "NUXT_3_REVIEW_APP_NAME=docurba-nuxt3-pr${PR_ID}" >> $GITHUB_ENV
         echo "NUXT_2_REVIEW_APP_NAME=${SCALINGO_NUXT_APP_NAME}-pr${PR_ID}" >> $GITHUB_ENV
         echo "DJANGO_REVIEW_APP_NAME=${SCALINGO_DJANGO_APP_NAME}-pr${PR_ID}" >> $GITHUB_ENV
+        echo "REVPROXY_REVIEW_APP_NAME=${SCALINGO_REVPROXY_APP_NAME}-pr${PR_ID}" >> $GITHUB_ENV
+        echo "REVPROXY_URL=https://${SCALINGO_REVPROXY_APP_NAME}-pr${PR_ID}.osc-fr1.scalingo.io" >> $GITHUB_ENV
 
     # La version est figée car la dernière version casse lors de l'envoi de la configuration.
     # L'erreur est cryptique.
@@ -171,6 +174,23 @@ jobs:
         django_url=$(scalingo --app "${DJANGO_REVIEW_APP_NAME}" env-get APP_URL)
         echo "DJANGO_URL=${django_url}" >> $GITHUB_ENV
 
+    - name: 🪆 Création de la recette jetable Nginx
+      run: |
+        scalingo --app ${SCALINGO_REVPROXY_APP_NAME} integration-link-manual-review-app ${{ github.event.number }}
+        scalingo --app "${REVPROXY_REVIEW_APP_NAME}" env-set \
+         DJANGO_URL="${DJANGO_URL}" \
+         NUXT_URL="${NUXT_URL}"
+        scalingo --app "${REVPROXY_REVIEW_APP_NAME}" integration-link-update --auto-deploy --branch "${BRANCH}" --destroy-on-close
+
+    - name: 🪆 Déploiement de la recette jetable Nginx
+      run: |
+        scalingo --app "${REVPROXY_REVIEW_APP_NAME}" integration-link-manual-deploy "${BRANCH}" &> /dev/null
+        until scalingo apps | grep "${REVPROXY_REVIEW_APP_NAME}" | grep --quiet 'running' &> /dev/null
+        do
+          echo "En attente de l'application Django pendant 10 secondes."
+          sleep 10s
+        done
+
     - name: 🤹‍♀️ Intégration de l'URL de Django dans Nuxt2
       run: scalingo --app "${NUXT_2_REVIEW_APP_NAME}" env-set APP_URL="${DJANGO_URL}"
 
@@ -178,13 +198,13 @@ jobs:
     # Configurée dans supabase/config.toml et dans l'interface : Supabase > Authorization > URL configuration.
     - name: 🤹‍♀️ Mise à jour de la configuration de Supabase
       continue-on-error: true
-      run: APP_URL="${DJANGO_URL}" supabase --project-ref "${SUPABASE_BRANCH_ID}" --yes config push
+      run: APP_URL="${REVPROXY_URL}" supabase --project-ref "${SUPABASE_BRANCH_ID}" --yes config push
 
     - name: 🍻 Ajout du lien en commentaire de la PR
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
         message: |-
-          🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](${{ env.DJANGO_URL }})
+          🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](${{ env.REVPROXY_URL }})
           Lien vers Nuxt3 pour modifier le déclencheur : [${{ env.NUXT3_URL }}](${{ env.NUXT3_URL }}).
           Attention, les données ne sont pas encore importées. Revenez quand l'action GitHub sera terminée.
 

--- a/django/.env.example
+++ b/django/.env.example
@@ -1,7 +1,6 @@
 export PYTHONPATH="."
 export DJANGO_SETTINGS_MODULE="config.settings.dev"
 export SECRET_KEY="xxxx" # django-admin generate_secret_key
-export UPSTREAM_NUXT="http://localhost:3000"
 export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 
 # scripts/backup_database.sh

--- a/django/config/settings/base.py
+++ b/django/config/settings/base.py
@@ -29,7 +29,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
-    "revproxy.apps.RevProxyConfig",
     "docurba.core",
     "docurba.surveys",
     "docurba.users",
@@ -179,5 +178,4 @@ sentry_sdk.init(
 ############ Docurba settings ############
 ##########################################
 
-UPSTREAM_NUXT = env.str("UPSTREAM_NUXT", default="http://localhost:3000")
 CREATE_UNMANAGED_TABLES = False

--- a/django/config/settings/dev.py
+++ b/django/config/settings/dev.py
@@ -10,8 +10,10 @@ INSTALLED_APPS.extend(
         "django_browser_reload",
         "django_extensions",
         "debug_toolbar",
+        "corsheaders",
     ]
 )
+
 
 # https://whitenoise.readthedocs.io/en/stable/django.html
 INSTALLED_APPS.insert(
@@ -24,6 +26,11 @@ MIDDLEWARE += [
     "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
 
+MIDDLEWARE.insert(
+    MIDDLEWARE.index("django.middleware.security.SecurityMiddleware") + 1,
+    "corsheaders.middleware.CorsMiddleware",
+)
+
 TEMPLATES[0]["OPTIONS"]["context_processors"].append(
     "django.template.context_processors.debug"
 )
@@ -33,3 +40,5 @@ del LOGGING["handlers"]["console"]["formatter"]
 
 SESSION_COOKIE_SECURE = False
 SECURE_SSL_REDIRECT = False
+
+CORS_ALLOWED_ORIGINS = ["http://localhost:3000"]

--- a/django/config/urls.py
+++ b/django/config/urls.py
@@ -1,12 +1,8 @@
 from django.conf import settings
 from django.contrib import admin
-from django.http import HttpResponseNotFound
-from django.urls import include, path, re_path
-from revproxy.views import ProxyView
+from django.urls import include, path
 
 from docurba.core import views as core_views
-
-nuxt_proxy = ProxyView.as_view(upstream=settings.UPSTREAM_NUXT)
 
 urlpatterns = [
     path("_admin/", admin.site.urls),
@@ -20,45 +16,10 @@ urlpatterns = [
     path("api/communes", core_views.api_communes, name="api_communes"),
     path("api/scots", core_views.api_scots, name="api_scots"),
     path("api-internes/", include("docurba.internal_api.urls")),
-    # URLs Nuxt globales
-    path("", nuxt_proxy, {"path": ""}),
-    re_path(r"(?P<path>^_content.*)", nuxt_proxy),
-    re_path(r"(?P<path>^_nuxt.*)", nuxt_proxy),
-    re_path(r"(?P<path>^api.*)", nuxt_proxy),
-    # URLs Nuxt dans nuxt/static
-    re_path(r"(?P<path>^favicon.*)", nuxt_proxy),
-    re_path(r"(?P<path>^fonts.*)", nuxt_proxy),
-    re_path(r"(?P<path>^images.*)", nuxt_proxy),
-    re_path(r"(?P<path>^json.*)", nuxt_proxy),
-    re_path(r"(?P<path>^pdf.*)", nuxt_proxy),
-    re_path(r"(?P<path>^ressources.*)", nuxt_proxy),
-    re_path(r"(?P<path>^sw.js)", nuxt_proxy),
-    # URLs Nuxt trouvées via this.$router.options.routes
-    re_path(r"(?P<path>^accessibilite.*)", nuxt_proxy),
-    re_path(r"(?P<path>^bureau-etude-urbanisme.*)", nuxt_proxy),
-    re_path(r"(?P<path>^collectivites.*)", nuxt_proxy),
-    re_path(r"(?P<path>^confidentialite.*)", nuxt_proxy),
-    re_path(r"(?P<path>^ddt.*)", nuxt_proxy),
-    re_path(r"(?P<path>^dev.*)", nuxt_proxy),
-    re_path(r"(?P<path>^documents.*)", nuxt_proxy),
-    re_path(r"(?P<path>^exports.*)", nuxt_proxy),
-    re_path(r"(?P<path>^frise.*)", nuxt_proxy),
-    re_path(r"(?P<path>^guide.*)", nuxt_proxy),
-    re_path(r"(?P<path>^login.*)", nuxt_proxy),
-    re_path(r"(?P<path>^loi-climat-et-resilience.*)", nuxt_proxy),
-    re_path(r"(?P<path>^mentions-legales.*)", nuxt_proxy),
-    re_path(r"(?P<path>^print.*)", nuxt_proxy),
-    re_path(r"(?P<path>^stats.*)", nuxt_proxy),
-    re_path(r"(?P<path>^trames.*)", nuxt_proxy),
-    re_path(r"(?P<path>^validation.*)", nuxt_proxy),
 ]
 
 if settings.DEBUG:
-    urls = [
-        path(  # Désactive le websocket hot reload Nuxt en dev
-            "_content/ws", lambda _: HttpResponseNotFound()
-        ),
-    ]
+    urls = []
     if "debug_toolbar" in settings.INSTALLED_APPS:
         from debug_toolbar.toolbar import debug_toolbar_urls
 

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "django-browser-reload",
     "django-debug-toolbar",
     "django-extensions",
+    "django-cors-headers",
     "ptpython",
     "pytest-cov",
     "pytest>=9.0.3",

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.13"
 dependencies = [
     "django",
     "django-environ",
-    "django-revproxy",
     "gunicorn[gevent]",
     "psycopg[binary,pool]",
     "sentry-sdk[django]",

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -234,18 +234,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-revproxy"
-version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-    { name = "urllib3" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/76/7781f0b011521b4f6eab515a21bf021ff78db52de4075cc61f1a0bcc70a6/django_revproxy-0.13.0-py3-none-any.whl", hash = "sha256:6130d52d5042624c918134369be0a825e9f7e87d15e12b739d6666e5ed1f32ef", size = 19476, upload-time = "2024-11-06T07:05:11.551Z" },
-]
-
-[[package]]
 name = "djangorestframework"
 version = "3.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -265,7 +253,6 @@ dependencies = [
     { name = "django" },
     { name = "django-datadog-logger" },
     { name = "django-environ" },
-    { name = "django-revproxy" },
     { name = "djangorestframework" },
     { name = "gunicorn", extra = ["gevent"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -292,7 +279,6 @@ requires-dist = [
     { name = "django" },
     { name = "django-datadog-logger" },
     { name = "django-environ" },
-    { name = "django-revproxy" },
     { name = "djangorestframework", specifier = ">=3.17.1" },
     { name = "gunicorn", extras = ["gevent"] },
     { name = "psycopg", extras = ["binary", "pool"] },

--- a/django/uv.lock
+++ b/django/uv.lock
@@ -186,6 +186,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
+]
+
+[[package]]
 name = "django-datadog-logger"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -263,6 +276,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "django-browser-reload" },
+    { name = "django-cors-headers" },
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
     { name = "factory-boy" },
@@ -289,6 +303,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "django-browser-reload" },
+    { name = "django-cors-headers" },
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
     { name = "factory-boy" },

--- a/reverse_proxy/servers.conf.erb
+++ b/reverse_proxy/servers.conf.erb
@@ -1,0 +1,50 @@
+# See https://doc.scalingo.com/platform/deployment/buildpacks/nginx
+# & https://doc.scalingo.com/platform/app/static-files-hosting#using-nginx-as-web-server
+
+# limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
+
+server {
+    server_name localhost;
+    listen <%= ENV['PORT'] %>;
+
+    charset utf-8;
+
+    # location /_admin {
+    #   proxy_pass <%= ENV["DJANGO_URL"] %>;
+    # }
+    # location /api/perimetres {
+    #   proxy_pass <%= ENV["DJANGO_URL"] %>;
+    # }
+    # location /api/communes {
+    #   proxy_pass <%= ENV["DJANGO_URL"] %>;
+    # }
+    # location /api/scots {
+    #   proxy_pass <%= ENV["DJANGO_URL"] %>;
+    # }
+    # location /api-internes {
+    #   proxy_pass <%= ENV["DJANGO_URL"] %>;
+    # }
+    # location /static {
+    #   proxy_pass <%= ENV["DJANGO_URL"] %>;
+    # }
+
+    # location / {
+    #   proxy_pass <%= ENV["NUXT_URL"] %>;
+    # }
+
+    location ~ (/api-internes|/api/communes|/api/scots|/api/perimetres|/_admin|/static) {
+      proxy_pass <%= ENV["DJANGO_URL"] %>;
+      # proxy_set_header Host $host;
+      # proxy_set_header X-Real-IP $remote_addr;
+      # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+      proxy_pass <%= ENV["NUXT_URL"] %>;
+      # proxy_set_header Host $host;
+      # proxy_set_header X-Real-IP $remote_addr;
+      # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/reverse_proxy/servers.conf.erb
+++ b/reverse_proxy/servers.conf.erb
@@ -34,7 +34,7 @@ server {
 
     location ~ (/api-internes|/api/communes|/api/scots|/api/perimetres|/_admin|/static) {
       proxy_pass <%= ENV["DJANGO_URL"] %>;
-      # proxy_set_header Host $host;
+      proxy_set_header Host <%= ENV["DJANGO_URL"] %>;
       # proxy_set_header X-Real-IP $remote_addr;
       # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       # proxy_set_header X-Forwarded-Proto $scheme;
@@ -42,7 +42,7 @@ server {
 
     location / {
       proxy_pass <%= ENV["NUXT_URL"] %>;
-      # proxy_set_header Host $host;
+      proxy_set_header Host <%= ENV["NUXT_URL"] %>;
       # proxy_set_header X-Real-IP $remote_addr;
       # proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       # proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
- Création d'une application nginx reverse-proxy, dont les regles de dispatch sont définies dans` reverse_proxy/nginx.conf.erb` (Voir la doc [scalingo](https://doc.scalingo.com/platform/deployment/buildpacks/nginx))
- Suppression de django-revproxy
- Utilisation directe des endpoints en local (config dev) grâce à l'ajout de la librairie corsheader