### PR TITLE
Sélectionner la section de trame présente dans l'URL de la page

### DIFF
--- a/nuxt/pages/trames/_githubRef.vue
+++ b/nuxt/pages/trames/_githubRef.vue
@@ -170,7 +170,7 @@ export default {
       collectivite: null,
       editable: false,
       opening: false,
-      searchedSectionPath: null,
+      searchedSectionPath: this.$route.query.path ?? null,
       shareDialog: false,
       loadingPdf: false,
       renameMode: false,


### PR DESCRIPTION
Les boutons « copier le lien de la section » dans la trame utilisent le paramètre `path` de la query de l'URL mais ce paramètre était ignoré au chargement de la page.