### PR TITLE
Modifier la procédure ou changer la date de l'évènement de lancement quand les deux ne sont pas compatibles

### DIFF
--- a/nuxt/components/Frise/EventForm.vue
+++ b/nuxt/components/Frise/EventForm.vue
@@ -18,6 +18,19 @@
                 <v-col cols="12">
                   <VTextDatePicker v-model="event.date_iso" label="Date de l'évènement" />
                 </v-col>
+                <v-col v-if="!validDate" cols="12">
+                  <validation-provider
+                    v-slot="{ errors }"
+                    :custom-messages="{ required: 'Cochez cette case ou changez la date de l\'évènement' }"
+                    :rules="{ required: { allowFalse: false } }"
+                  >
+                    <v-checkbox
+                      v-model="overrideHuwartField"
+                      :error-messages="errors"
+                      :label="`Cet évènement de lancement est ${procedure.started_before_huwart_law ? 'postérieur' : 'antérieur'} à la loi Huwart mais la procédure a été définie comme ${procedure.started_before_huwart_law ? 'antérieure' : 'postérieure'} à la loi Huwart. Cochez cette case pour changer la définition de la procédure.`"
+                    />
+                  </validation-provider>
+                </v-col>
                 <v-col cols="12">
                   <v-textarea
                     v-model="event.description"
@@ -100,6 +113,8 @@
 import axios from 'axios'
 import { mdiTrashCan } from '@mdi/js'
 import FormInput from '@/mixins/FormInput.js'
+import { getEventPhase } from '@/plugins/event'
+
 export default {
   mixins: [FormInput],
   props: {
@@ -145,7 +160,22 @@ export default {
       icons: { mdiTrashCan },
       loading: !!this.eventId,
       saving: false,
-      deleteModal: false
+      deleteModal: false,
+      overrideHuwartField: false
+    }
+  },
+  computed: {
+    // Check if the lauch event date is compatible with the before Huwart law procedure field
+    validDate () {
+      return !this.event.date_iso ||
+        !this.launchEvent ||
+        this.procedure.started_before_huwart_law === (
+          new Date(this.event.date_iso) < new Date('2026-05-26')
+        )
+    },
+    launchEvent () {
+      return !!this.event.type &&
+        getEventPhase(this.procedure.doc_type, this.event.type) === 'Définition des modalités'
     }
   },
   mounted () {
@@ -179,6 +209,11 @@ export default {
         } else {
           const { data: savedEvents } = await this.$supabase.from('doc_frise_events').insert(upsertEvent).select()
           await this.saveAttachements(savedEvents[0].id)
+        }
+        if (this.overrideHuwartField) {
+          await this.$supabase.from('procedures').update({
+            started_before_huwart_law: !this.procedure.started_before_huwart_law
+          }).eq('id', this.procedure.id)
         }
 
         this.$analytics({

--- a/nuxt/components/Frise/EventForm.vue
+++ b/nuxt/components/Frise/EventForm.vue
@@ -27,7 +27,7 @@
                     <v-checkbox
                       v-model="overrideHuwartField"
                       :error-messages="errors"
-                      :label="`Cet évènement de lancement est ${procedure.started_before_huwart_law ? 'postérieur' : 'antérieur'} à la loi Huwart mais la procédure a été définie comme ${procedure.started_before_huwart_law ? 'antérieure' : 'postérieure'} à la loi Huwart. Cochez cette case pour changer la définition de la procédure.`"
+                      :label="`Cet évènement de lancement est ${procedure.started_before_huwart_law ? 'postérieur' : 'antérieur'} au 26 mai 2026 mais la procédure a été définie comme lancée ${procedure.started_before_huwart_law ? 'avant' : 'après'} le 26 mai 2026 lors de sa création. Cochez cette case pour changer la définition de cette procédure.`"
                     />
                   </validation-provider>
                 </v-col>
@@ -113,7 +113,7 @@
 import axios from 'axios'
 import { mdiTrashCan } from '@mdi/js'
 import FormInput from '@/mixins/FormInput.js'
-import { getEventPhase } from '@/plugins/event'
+import { getLaunchEvent } from '@/plugins/event'
 
 export default {
   mixins: [FormInput],
@@ -174,8 +174,7 @@ export default {
         )
     },
     launchEvent () {
-      return !!this.event.type &&
-        getEventPhase(this.procedure.doc_type, this.event.type) === 'Définition des modalités'
+      return !!this.event.type && getLaunchEvent(this.event.type)
     }
   },
   mounted () {

--- a/nuxt/pages/frise/_procedureId/_eventId.vue
+++ b/nuxt/pages/frise/_procedureId/_eventId.vue
@@ -41,7 +41,7 @@ export default {
       }
     })
 
-    const { data: procedure, error: errorProcedure } = await this.$supabase.from('procedures').select('project_id, id, type, doc_type, current_perimetre, collectivite_porteuse_id').eq('id', this.$route.params.procedureId)
+    const { data: procedure, error: errorProcedure } = await this.$supabase.from('procedures').select('project_id, id, type, doc_type, current_perimetre, collectivite_porteuse_id, started_before_huwart_law').eq('id', this.$route.params.procedureId)
     if (errorProcedure) { throw errorProcedure }
     this.procedure = procedure[0]
 

--- a/nuxt/plugins/event.js
+++ b/nuxt/plugins/event.js
@@ -24,6 +24,13 @@ export function getDocumentTypeEvents (documentType) {
   }
 }
 
+export function getEventPhase (documentType, eventType) {
+  const documentTypeEvents = getDocumentTypeEvents(documentType)
+  const event = documentTypeEvents.find(({ name }) => name === eventType)
+
+  return (event && event.phases) ?? null
+}
+
 export function getProcedureEventsScope (procedure) {
   if (!procedure) {
     return 'aucun'

--- a/nuxt/plugins/event.js
+++ b/nuxt/plugins/event.js
@@ -24,11 +24,14 @@ export function getDocumentTypeEvents (documentType) {
   }
 }
 
-export function getEventPhase (documentType, eventType) {
-  const documentTypeEvents = getDocumentTypeEvents(documentType)
-  const event = documentTypeEvents.find(({ name }) => name === eventType)
-
-  return (event && event.phases) ?? null
+export function getLaunchEvent (eventType) {
+  return [
+    'Arrêté de lancement de la procédure',
+    'Délibération de l\'établissement public qui prescrit',
+    'Délibération de prescription du conseil métropolitain',
+    'Délibération de prescription du conseil municipal',
+    'Délibération de prescription du conseil municipal ou communautaire'
+  ].includes(eventType)
 }
 
 export function getProcedureEventsScope (procedure) {


### PR DESCRIPTION
Quand la procédure est désignée comme datant d'avant la loi Huwart, l'évènement de lancement doit être daté d'avant le 26 mai 2026 et inversement.

La case n'apparait que si la procédure et la date de l'évènement de lancement sont incompatibles.

Procédure : avant la loi Huwart
Évènement : après la loi Huwart
<img width="1170" height="271" alt="after-event-before-procedure" src="https://github.com/user-attachments/assets/03c4d83b-cf93-4c1e-ab0e-4f544e4fbcd6" />
Procédure : après la loi Huwart
Évènement : avant la loi Huwart
<img width="1168" height="275" alt="before-event-after-procedure" src="https://github.com/user-attachments/assets/f379e161-1c43-4f1d-b138-350172589bf5" />
Quand on essaie de soumettre le formulaire sans avoir coché la case
<img width="1166" height="290" alt="before-event-after-procedure-error" src="https://github.com/user-attachments/assets/b9df7121-8c93-4110-a5e8-6ddc2ef8913a" />
