### PR TITLE
Utiliser l'API Django pour récupérer les collectivités sur la page « Mes procédures »

### DIFF
--- a/nuxt/pages/ddt/_departement/procedures/index.vue
+++ b/nuxt/pages/ddt/_departement/procedures/index.vue
@@ -256,10 +256,16 @@ export default {
         this.$nuxt.context.redirect(302, '/')
       }
       const promProcedures = await this.$urbanisator.getProceduresForDept(this.$route.params.departement)
-      const rawReferentiel = fetch(`/api/geo/collectivites?departements=${this.$route.params.departement}`)
+      const promCommunes = this.$djangoApi.get('/communes/', {
+        departement: this.$route.params.departement
+      })
+      const promGroupements = this.$djangoApi.get('/collectivites/', {
+        departement: this.$route.params.departement,
+        without_communes: true,
+        competence: ['plan', 'schema']
+      })
 
-      const [rawProcedures, referentiel] = await Promise.all([promProcedures, rawReferentiel])
-      const { communes, groupements } = await referentiel.json()
+      const [rawProcedures, communes, groupements] = await Promise.all([promProcedures, promCommunes, promGroupements])
       this.rawProcedures = rawProcedures.map((e) => {
         let collectivitePorteuse
         if (e.perimetre.length > 1) {


### PR DESCRIPTION
Suite à [ce changement](https://github.com/MTES-MCT/Docurba/commit/d5074721430f362af74997567d216a6cb59fca4b#diff-92bb0e5f7b0ca97dbeafbcce032d8fbf1c8f18602c44e1d47b4e60b5b14eddbcL45) la requête pour récupérer les collectivités depuis la page « Mes procédures » échoue. La raison étant qu'on utilise le paramètre `departements` et pas le paramètre `code` lors de cette requête.

Pour corriger ça, cette PR modifie la requête pour qu'elle utilise l'api de communes/collectivites de Django.