### PR TITLE
Masquer les projets générés automatiquement à la création de procédure

### DIFF
--- a/nuxt/pages/ddt/_departement/pac.vue
+++ b/nuxt/pages/ddt/_departement/pac.vue
@@ -199,6 +199,7 @@ export default {
         .from('projects')
         .select('id, name, doc_type, towns, collectivite_id, trame, region, PAC, created_at')
         .not('collectivite_id', 'is', null)
+        .not('trame', 'is', null)
         .match({
           owner: this.$user.id,
           archived: false
@@ -208,15 +209,18 @@ export default {
         .from('projects_sharing')
         .select('id, role, created_at, profiles (user_id, firstname, lastname), projects (id, name, doc_type, towns, collectivite_id, trame, region, PAC, created_at)')
         .not('projects.collectivite_id', 'is', null)
+        .not('projects.trame', 'is', null)
         .match({
           user_email: this.$user.email,
           'projects.archived': false
         })
 
+      const ownProjectsIds = ownProjects.map(({ id }) => id)
+
       this.projects = [
         ...ownProjects,
         ...sharings
-          .filter(sharing => sharing.projects)
+          .filter(sharing => sharing.projects && !ownProjectsIds.includes(sharing.projects.id))
           .map(sharing => ({
             ...sharing.projects,
             sharing: {


### PR DESCRIPTION
Créer une procédure créé automatiquement un projet associé. Ces projets ne sont pas des PAC mais ils apparaissent comme tel sur la page « Mes PAC ».

Il y a plusieurs endroits qui dépendent du fait qu'une procédure ai un `project_id` donc supprimer cette création de projet pourrait avoir des side-effects imprévus.

Pour éviter de créer de l'instabilité, cette PR se contente de masquer les projets en question de la page « Mes PAC » en se basant sur le fait que les projets créés par la création de procédure n'ont pas de `trame` contrairement aux PACs créés manuellement.