### PR TITLE
Détecter les différents évènements de prescription

### DIFF
--- a/nuxt/plugins/event.js
+++ b/nuxt/plugins/event.js
@@ -34,15 +34,15 @@ export function getLaunchEvent (eventType) {
   ].includes(eventType)
 }
 
-export function getPrescriptionEvent (eventType) {
-  return [
+export function getPrescriptionEvent (event) {
+  return !!event.is_valid && [
     'Délibération de l\'établissement public qui prescrit',
     'Délibération de l\'Etablissement Public',
     'Délibération de prescription du conseil métropolitain',
     'Délibération de prescription du conseil municipal ou communautaire',
     'Délibération de prescription du conseil municipal',
     'Prescription'
-  ].includes(eventType)
+  ].includes(event.type)
 }
 
 export function getProcedureEventsScope (procedure) {

--- a/nuxt/plugins/event.js
+++ b/nuxt/plugins/event.js
@@ -34,6 +34,17 @@ export function getLaunchEvent (eventType) {
   ].includes(eventType)
 }
 
+export function getPrescriptionEvent (eventType) {
+  return [
+    'Délibération de l\'établissement public qui prescrit',
+    'Délibération de l\'Etablissement Public',
+    'Délibération de prescription du conseil métropolitain',
+    'Délibération de prescription du conseil municipal ou communautaire',
+    'Délibération de prescription du conseil municipal',
+    'Prescription'
+  ].includes(eventType)
+}
+
 export function getProcedureEventsScope (procedure) {
   if (!procedure) {
     return 'aucun'

--- a/nuxt/plugins/urbanisator.js
+++ b/nuxt/plugins/urbanisator.js
@@ -38,7 +38,7 @@ export default ({ $supabase, $dayjs }, inject) => {
           ),
           'date_iso'
         )
-        const prescription = e.procedures.doc_frise_events.find(y => getPrescriptionEvent(y.type))
+        const prescription = e.procedures.doc_frise_events.find(getPrescriptionEvent)
         return { ...e, perimetre: groupedProceduresPerim[e.procedure_id], last_event: lastEvent, prescription }
       })
       const uniqProcedures = uniqBy(procedures, e => e.procedure_id)

--- a/nuxt/plugins/urbanisator.js
+++ b/nuxt/plugins/urbanisator.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { groupBy, uniqBy, orderBy, maxBy } from 'lodash'
 import axios from 'axios'
+import { getPrescriptionEvent } from '@/plugins/event'
 
 export default ({ $supabase, $dayjs }, inject) => {
   Vue.filter('docType', function (procedure) {
@@ -37,7 +38,7 @@ export default ({ $supabase, $dayjs }, inject) => {
           ),
           'date_iso'
         )
-        const prescription = e.procedures.doc_frise_events.find(y => y.code === 'PRES')
+        const prescription = e.procedures.doc_frise_events.find(y => getPrescriptionEvent(y.type))
         return { ...e, perimetre: groupedProceduresPerim[e.procedure_id], last_event: lastEvent, prescription }
       })
       const uniqProcedures = uniqBy(procedures, e => e.procedure_id)


### PR DESCRIPTION
Un évènement était détecté sur la page « Mes procédures » uniquement s'il avait le code `PRES`.

Cette PR modifie la détection pour ajouter les autres types d'évènments valant prescription