### PR TITLE
Correction de la création des événements en recette jetable

### DIFF
--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -356,9 +356,9 @@ jobs:
     - name: 🔂 Génération des données
       run: scalingo --app "${{ needs.prepare.outputs.DJANGO_REVIEW_APP_NAME }}" run './scripts/restore_database.sh ${DATABASE_URL}' &> /dev/null
 
-    - name: ⏩ Lancement des migrations
+    - name: ⏩ Lancement des migrations et mise à jour du déclencheur utilisant Nuxt3
       run: |
         # La connexion PG doit être libérée avant de pouvoir passer les migrations
         # mais on ne sait jamais combien de temps Supabase met à le faire.
         sleep 5m
-        scalingo --app "${{ needs.prepare.outputs.DJANGO_REVIEW_APP_NAME }}" run 'django-admin migrate'
+        scalingo --app "${{ needs.prepare.outputs.DJANGO_REVIEW_APP_NAME }}" run 'django-admin update_nuxt3_trigger && django-admin migrate'

--- a/django/docurba/core/management/commands/update_nuxt3_trigger.py
+++ b/django/docurba/core/management/commands/update_nuxt3_trigger.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+def update_trigger_sql(nuxt3_url: str) -> str:
+    return f"""
+    ALTER TABLE doc_frise_events
+    DISABLE TRIGGER trigger_event_procedure_status_handler;
+
+    CREATE OR REPLACE FUNCTION public.event_procedure_status_handler() RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$ declare procedure procedures; event_processed doc_frise_events;
+        BEGIN
+            IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' then event_processed := new;
+            else event_processed := old;
+            END IF;
+            SELECT * into procedure FROM procedures WHERE id = event_processed.procedure_id;
+            PERFORM set_procedure_status(procedure);
+            /* NUXT3_API_URL is hardcoded here because this dump will disappear soon and I don't know how to change it quickly in SQL. */
+            PERFORM net.http_get('{nuxt3_url}/api/urba/procedures/' || event_processed.procedure_id || '/update');
+        return event_processed; END; $$;
+
+            ALTER TABLE doc_frise_events
+    ENABLE TRIGGER trigger_event_procedure_status_handler;
+    """  # noqa: S608
+
+
+class Command(BaseCommand):
+    help = "Update the trigger calling Nuxt3's endpoint."
+
+    def handle(self, *args: list, **options: dict) -> None:  # noqa: ARG002
+        if not settings.NUXT3_API_URL:
+            raise KeyError("NUXT3_API_URL is not set.")  # noqa: EM101, TRY003
+
+        with connection.cursor() as cursor:
+            cursor.execute(update_trigger_sql(nuxt3_url=settings.NUXT3_API_URL))
+        self.stdout.write(
+            "event_procedure_status_handler has been updated successfully."
+        )


### PR DESCRIPTION
The core.0027 migration has already been launched on the
production database so it's not run anymore on review apps.
Instead, update it explicitely each time we create a review app.
It should be a bash script but substenv is not available on the
scalingo24 image and we don't want to install another dependency.
This behaviour should soon be erased when Nuxt3 will be dead.
