### PR TITLE
Démo et recettes : correction du script de restauration des données

### DIFF
--- a/django/scripts/restore_database.sh
+++ b/django/scripts/restore_database.sh
@@ -73,6 +73,12 @@ if [[ ${BACKUPS_DELETE_URL_IN_DUMP_FILE} == "True" ]]; then
 fi
 
 echo "Début de la restauration."
+# Malgré le --clean passé au pg_dump, la base n'est pas bien nettoyée avant
+# d'être restaurée. Assurons-nous qu'elle est vide avant la restauration.
+psql \
+  --command 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;' \
+  --dbname ${database_restoration_url}
+
 # Comme décrit dans la documentation de Supabase.
 # J'ai supprimé l'option `--variable ON_ERROR_STOP=1` pour restaurer malgré des erreurs.
 # `session_replication_role` est déjà ajouté lors de la sauvegarde je ne souhaite


### PR DESCRIPTION
In the demo environment, the database is already populated with data
when we restore it. Apparently, the `--clean` option does not seem to
really clean the database before we restore it.
As we should get rid of Supabase throughout the year,
let's don't invest too much time investigating this bug.
Instead, take a brutal path and just drop the public schema.
