### PR TITLE
Django admin : avoir une vue d'ensemble de toutes les procédures dont le périmètre inclue une commune

### DIFF
--- a/django/config/settings/base.py
+++ b/django/config/settings/base.py
@@ -85,7 +85,7 @@ DATABASES = {
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [APPS_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/django/config/urls.py
+++ b/django/config/urls.py
@@ -6,12 +6,6 @@ from docurba.core import views as core_views
 
 urlpatterns = [
     path("_admin/", admin.site.urls),
-    path("collectivite/<collectivite_code>/", core_views.collectivite),
-    path(
-        "collectivite/<collectivite_code>/<collectivite_type>/",
-        core_views.collectivite,
-        name="collectivite-detail",
-    ),
     path("api/perimetres", core_views.api_perimetres, name="api_perimetres"),
     path("api/communes", core_views.api_communes, name="api_communes"),
     path("api/scots", core_views.api_scots, name="api_scots"),

--- a/django/docurba/core/admin.py
+++ b/django/docurba/core/admin.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.contrib import admin
 from django.db import models
 from django.forms.models import ModelForm
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
 from django.utils.html import format_html
 
 from docurba.core.enums import TypeCollectivite
@@ -46,7 +48,50 @@ class CollectiviteAdmin(admin.ModelAdmin):
 
 @admin.register(Commune)
 class CommuneAdmin(CollectiviteAdmin):
-    pass
+    change_form_template = "admin/core/commune/procedures.html"
+
+    def get_extra_context(self, object_id) -> dict:
+        commune = get_object_or_404(
+            Commune.objects.with_procedures_principales(), pk=object_id
+        )
+        procedures = (
+            commune.procedures.filter(parente=None)
+            .with_events()
+            .order_by("doc_type", "-created_at")
+        )
+        for procedure in procedures:
+            procedure.is_opposable = commune.is_opposable(procedure)
+        return {"procedures": procedures}
+
+    # We cant use inlines here as they only work with ForeignKey and not with ForeignObject (CommuneProcedure.commune)
+    def change_view(
+        self, request, object_id, form_url="", extra_context=None
+    ) -> HttpResponse:
+        extra_context = extra_context or {}
+        extra_context.update(self.get_extra_context(admin.utils.unquote(object_id)))
+        return super().change_view(
+            request,
+            object_id,
+            form_url,
+            extra_context=extra_context,
+        )
+
+    def get_queryset(self, request) -> models.QuerySet:
+        queryset = super().get_queryset(request)
+        return queryset.with_procedures_principales()
+
+    def get_readonly_fields(self, request, obj=None) -> tuple[str]:
+        readonly = super().get_readonly_fields(request, obj)
+
+        return (*readonly, "code_etat_simplifie", "code_etat_complet")
+
+    @admin.display(description="Code état Simplifié")
+    def code_etat_simplifie(self, obj) -> str:
+        return f"{obj.code_etat_simplifie} - {obj.libelle_code_etat_simplifie}"
+
+    @admin.display(description="Code état Complet")
+    def code_etat_complet(self, obj) -> str:
+        return f"{obj.code_etat_complet} - {obj.libelle_code_etat_complet}"
 
 
 class ProcedurePerimetreInline(admin.TabularInline):

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -1,10 +1,7 @@
 from csv import DictWriter
 from datetime import date
-from itertools import groupby
-from operator import attrgetter
 
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
-from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_safe
 
 from docurba.core.enums import TypeCollectivite
@@ -386,38 +383,3 @@ def api_scots(request: HttpRequest) -> HttpResponse:
         for scot_opposable, scot_en_cours in collectivite.scots_pour_csv
     )
     return response
-
-
-@require_safe
-def collectivite(
-    request: HttpRequest, collectivite_code: str, collectivite_type: str = "COM"
-) -> HttpResponse:
-    try:
-        avant = _avant(request)
-    except ValueError:
-        return HttpResponseBadRequest(
-            "Le paramètre 'avant' doit être une date valide au format YYYY-MM-DD."
-        )
-    commune_qs = Commune.objects.with_procedures_principales(avant=avant)
-    commune = get_object_or_404(
-        commune_qs, id=f"{collectivite_code}_{collectivite_type}"
-    )
-    is_schema = attrgetter("is_schema")
-    procedures_principales_by_schema = {
-        schema: [
-            (procedure, commune.is_opposable(procedure)) for procedure in procedures
-        ]
-        for schema, procedures in groupby(
-            sorted(commune.procedures_principales, key=is_schema),
-            key=is_schema,
-        )
-    }
-
-    return render(
-        request,
-        "core/collectivite.html",
-        {
-            "collectivite": commune,
-            "procedures_principales_by_schema": procedures_principales_by_schema,
-        },
-    )

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -415,7 +415,7 @@ def collectivite(
 
     return render(
         request,
-        "collectivite.html",
+        "core/collectivite.html",
         {
             "collectivite": commune,
             "procedures_principales_by_schema": procedures_principales_by_schema,

--- a/django/docurba/templates/admin/core/commune/procedures.html
+++ b/django/docurba/templates/admin/core/commune/procedures.html
@@ -1,0 +1,51 @@
+{% extends "admin/change_form.html" %}
+{% load admin_urls %}
+{% block after_related_objects %}
+{{ block.super }}
+<div class="inline-group">
+    <div class="tabular inline-related">
+        <fieldset class="module">
+            <h2 class="inline-heading"> Procédures dont le périmètre inclut la commune</h2>
+            <div class="wrapper">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Procedure</th>
+                            <th>Type document</th>
+                            <th>Opposable</th>
+                            <th>Statut</th>
+                            <th>Date prescription</th>
+                            <th>Date approbation</th>
+                            <th>Dernier event impactant</th>
+                            <th>Archivée</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for procedure in procedures %}
+                        <tr class="form-row">
+                            <td><p>
+                                <a href="{% url 'admin:core_procedure_change' procedure.pk %}">
+                                        {{ procedure.id }}
+                                </a>
+                                : {{ procedure }}
+                            </p></td>
+                            <td>
+                                <p>{{ procedure.type_document }}</p>
+                            </td>
+                            <td>
+                                <p>{% if procedure.is_opposable %}✅{% endif %}</p>
+                            </td>
+                            <td><p>{{ procedure.statut | default_if_none:"" }}</p></td>
+                            <td><p>{{ procedure.date_prescription | default_if_none:"" }}</p></td>
+                            <td><p>{{ procedure.date_approbation | default_if_none:"" }}</p></td>
+                            <td><p>{{ procedure.dernier_event_impactant | default_if_none:"" }}</p></td>
+                            <td><p>{% if procedure.archived %}✅{% endif %}</p></td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </fieldset>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Dans un premier temps : garder le comportement de la page de debug initiale et ne lister que les procédures principales