### PR TITLE
Utiliser la bonne variable et la bonne valeur pour la boucle de pagination de la requête à l'api django

### DIFF
--- a/nuxt/plugins/django-api.js
+++ b/nuxt/plugins/django-api.js
@@ -1,17 +1,15 @@
-/* eslint-disable unicorn/no-anonymous-default-export */
-import Qs from "qs"
+import Qs from 'qs'
 
 export default ({ $axios, $user }, inject) => {
   const djangoAxios = $axios.create({
     baseURL: process.env.DJANGO_API_BASE_URL,
-    paramsSerializer: params => Qs.stringify(params, {arrayFormat: 'repeat', encode: false})
+    paramsSerializer: params => Qs.stringify(params, { arrayFormat: 'repeat', encode: false })
   })
   inject('djangoApi', {
     async get (path, parameters) {
-      // eslint-disable-next-line n/prefer-global/process
       const requestOpts = { params: parameters }
       if ($user.supabase_access_token) {
-        requestOpts.headers = { "Supabase-Authorization": $user.supabase_access_token }
+        requestOpts.headers = { 'Supabase-Authorization': $user.supabase_access_token }
       }
       const { data: responseData } = await djangoAxios.get(path, requestOpts)
       if (responseData.results === undefined) {
@@ -22,10 +20,10 @@ export default ({ $axios, $user }, inject) => {
       results.push(...responseData.results)
       if (responseData.num_pages > 1) {
         let nextUrl = responseData.next
-        while (nextUrl !== undefined) {
+        while (nextUrl !== null) {
           const { data: response } = await $axios.get(nextUrl)
           results.push(...response.results)
-          nextUrl = results.next
+          nextUrl = response.next
         }
       }
 


### PR DESCRIPTION
Il y avait 2 soucis :

1. On allait chercher la valeur de l'url suivante à requêter dans l'`array` `results` au lieu de dans l'objet `response` retourné par la requête précédente
2. On vérifiait si la valeur de `next` était `undefined` mais la valeur retournée par la requête quand on est à la dernière page est `null`

(Les changements autres que les lignes 25/23 et 28/26 c'est juste pour que le linter soit content)