### PR TITLE
Ajouter la sélection pré/post loi Huwart aux procédures principales

### DIFF
--- a/nuxt/components/Dashboard/DUProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUProcedureItem.vue
@@ -24,11 +24,7 @@
           Type de procédure
         </div>
         <div>
-          {{ procedure.type }}{{
-            procedure.type === 'Modification' && procedure.started_before_huwart_law
-              ? ' (antérieure à la loi Huwart)'
-              : ''
-          }}
+          {{ procedureTypeLabel }}
         </div>
       </v-col>
       <v-col>

--- a/nuxt/components/Dashboard/DUSubProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUSubProcedureItem.vue
@@ -14,11 +14,7 @@
           Type de procédure
         </div>
         <div>
-          {{ procedure.type }}{{
-            procedure.type === 'Modification' && procedure.started_before_huwart_law
-              ? ' (antérieure à la loi Huwart)'
-              : ''
-          }}
+          {{ procedureTypeLabel }}
         </div>
       </v-col>
       <v-col>

--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -3,7 +3,7 @@
   <validation-observer v-else-if="(procedureCategory === 'principale' || (procedureCategory === 'secondaire' && proceduresParents && proceduresParents.length > 0))" :ref="`observerAddProcedure-${procedureCategory}`" v-slot="{ handleSubmit, invalid }">
     <form @submit.prevent="handleSubmit(createProcedure)">
       <v-container class="pa-0">
-        <v-row v-if="procedureCategory === 'secondaire'">
+        <v-row>
           <v-col cols="6">
             <v-checkbox
               v-model="startedBeforeHuwartLaw"
@@ -235,7 +235,12 @@ export default {
     },
     typesProcedure () {
       if (this.procedureCategory === 'principale') {
-        return ['Elaboration', 'Révision'].map(value => ({ text: value, value }))
+        return ['Elaboration', 'Révision'].map(value => ({
+          text: `${value} (${
+            this.startedBeforeHuwartLaw ? 'antérieure' : 'postérieure'
+          } à la loi Huwart)`,
+          value
+        }))
       }
 
       return [

--- a/nuxt/mixins/BaseDUProcedureItem.js
+++ b/nuxt/mixins/BaseDUProcedureItem.js
@@ -1,3 +1,5 @@
+import { getProcedureTypeLabel } from '@/plugins/procedure'
+
 export default {
   data () {
     return {
@@ -12,6 +14,9 @@ export default {
     }
   },
   computed: {
+    procedureTypeLabel () {
+      return getProcedureTypeLabel(this.procedure)
+    },
     step () {
       if (this.procedure.abort_date) {
         return `Abandon (${this.procedure.abort_date})`

--- a/nuxt/plugins/event.js
+++ b/nuxt/plugins/event.js
@@ -48,10 +48,12 @@ export function getDocumentTypeEvents (documentType) {
 export function getLaunchEvent (eventType) {
   return [
     'Arrêté de lancement de la procédure',
+    'Délibération de l\'Etablissement Public',
     'Délibération de l\'établissement public qui prescrit',
     'Délibération de prescription du conseil métropolitain',
     'Délibération de prescription du conseil municipal',
-    'Délibération de prescription du conseil municipal ou communautaire'
+    'Délibération de prescription du conseil municipal ou communautaire',
+    'Prescription'
   ].includes(eventType)
 }
 

--- a/nuxt/plugins/procedure.js
+++ b/nuxt/plugins/procedure.js
@@ -41,3 +41,17 @@ export function enrichProcedureWithEvents (procedure) {
     stop_event: stopEvent
   }
 }
+
+export function getProcedureTypeLabel (procedure) {
+  return procedure
+    ? `${procedure.type}${
+      [
+        'Elaboration',
+        'Modification',
+        'Révision'
+      ].includes(procedure.type) && procedure.started_before_huwart_law
+        ? ' (antérieure à la loi Huwart)'
+        : ''
+    }`
+    : ''
+}


### PR DESCRIPTION
Création de procédure principale datée d'avant le 26 mai 2026
<img width="476" height="365" alt="procedure-creation-before" src="https://github.com/user-attachments/assets/ced7d7a8-ba10-4af2-8d0d-cf975cf4f0d1" />

Création de procédure principale datée d'après le 26 mai 2026
<img width="486" height="366" alt="procedure-creation-after" src="https://github.com/user-attachments/assets/88c80d79-d4bc-4cc1-af55-08468680cb2e" />

Affichage du type d'une procédure principale datée d'avant le 26 mai 2026
<img width="883" height="641" alt="procedure-type" src="https://github.com/user-attachments/assets/18f7db6b-a133-423b-b52c-bcf98858fadf" />
