### PR TITLE
Django : ajout de l'environnement à la configuration du projet

### DIFF
--- a/.github/workflows/review_app_creation.yml
+++ b/.github/workflows/review_app_creation.yml
@@ -307,6 +307,7 @@ jobs:
         django_secret_key=$(python -c "import secrets; print(secrets.token_hex(60))")
         echo "::add-mask::${django_secret_key}";
         scalingo --app "${{ needs.prepare.outputs.DJANGO_REVIEW_APP_NAME }}" env-set \
+        DOCURBA_ENVIRONMENT="REVIEW-APP" \
         UPSTREAM_NUXT="${{ needs.prepare.outputs.NUXT_2_URL }}" \
         DATABASE_URL="${{ steps.db.outputs.POSTGRES_URL }}" \
         NUXT3_API_URL="${{ needs.prepare.outputs.NUXT_3_URL }}" \

--- a/django/.env.example
+++ b/django/.env.example
@@ -3,6 +3,7 @@ export DJANGO_SETTINGS_MODULE="config.settings.dev"
 export SECRET_KEY="xxxx" # django-admin generate_secret_key
 export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 export EVENT_TYPE_HELP_TEXT_URL="https://some_doc.com"
+export DOCURBA_ENVIRONMENT="DEV"
 
 export SUPABASE_ANON_KEY="<anon public> legacy API key"
 export SUPABASE_URL="http://127.0.0.1:54321"

--- a/django/config/settings/base.py
+++ b/django/config/settings/base.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import sentry_sdk
 from environ import Env
 
+from docurba.utils.enums import DocurbaEnvironment
+
 env = Env()
 env.smart_cast = False
 
@@ -17,6 +19,8 @@ EXPORTS_DIR = env.str("SCRIPT_EXPORT_PATH", default=f"{BASE_DIR}/exports")
 SECRET_KEY = env.str("SECRET_KEY", default="local_secret_key")
 DEBUG = False
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[])
+
+DOCURBA_ENVIRONMENT = DocurbaEnvironment(env.str("DOCURBA_ENVIRONMENT", default="PROD"))
 
 # Application definition
 

--- a/django/config/settings/dev.py
+++ b/django/config/settings/dev.py
@@ -6,6 +6,7 @@ from config.settings.base import *  # NOSONAR (S2208)
 # Django settings
 # ---------------
 DEBUG = True
+DOCURBA_ENVIRONMENT = DocurbaEnvironment.DEV
 
 INSTALLED_APPS.extend(
     [

--- a/django/config/settings/test.py
+++ b/django/config/settings/test.py
@@ -1,6 +1,8 @@
 # ruff: noqa: F405 F403
 from config.settings.base import *  # NOSONAR (S2208)
 
+DOCURBA_ENVIRONMENT = DocurbaEnvironment.TEST
+
 STORAGES["staticfiles"]["BACKEND"] = (
     "django.contrib.staticfiles.storage.StaticFilesStorage"
 )

--- a/django/docurba/utils/enums.py
+++ b/django/docurba/utils/enums.py
@@ -1,0 +1,9 @@
+import enum
+
+
+class DocurbaEnvironment(enum.StrEnum):
+    PROD = "PROD"
+    DEMO = "DEMO"
+    REVIEW_APP = "REVIEW-APP"
+    TEST = "TEST"
+    DEV = "DEV"


### PR DESCRIPTION
Différencier les environnements de prod, démo et recette jetable plus finement qu'actuellement.

À faire : mettre à jour les variables d'environnement de l'app Django de démo.