### PR TITLE
Correction de l'erreur 500 sur l'API Périmètres

### DIFF
--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -322,10 +322,6 @@ class ProcedureQuerySet(models.QuerySet):
             ),
         )
 
-    def without_adhesions_count(self) -> Self:
-        self.query.annotations.pop("communes_adherentes__count")
-        return self
-
     def with_concatenated_topics_as_string(self) -> Self:
         return self.annotate(
             concatenated_topics_as_string=StringAgg(
@@ -995,6 +991,16 @@ class Departement(models.Model):
 
 class CollectiviteQuerySet(models.QuerySet):
     def portant_scot(self, avant: date | None = None) -> Self:
+        procedures_qs = (
+            Procedure.objects.with_events(avant=avant)
+            .with_concatenated_topics_as_string()
+            .order_by("created_at")
+            .filter(
+                doc_type="SCOT",
+                parente=None,
+                archived=False,
+            )
+        )
         return (
             self.distinct()
             .filter(
@@ -1006,15 +1012,7 @@ class CollectiviteQuerySet(models.QuerySet):
             .prefetch_related(
                 models.Prefetch(
                     "procedure_set",
-                    Procedure.objects.with_events(avant=avant)
-                    .with_concatenated_topics_as_string()
-                    .without_adhesions_count()
-                    .order_by("created_at")
-                    .filter(
-                        doc_type="SCOT",
-                        parente=None,
-                        archived=False,
-                    ),
+                    procedures_qs,
                     to_attr="scots",
                 ),
                 models.Prefetch(
@@ -1098,16 +1096,12 @@ class Collectivite(models.Model):
 
 
 class CommuneQuerySet(models.QuerySet):
-    def with_procedures_principales(
-        self, *, avant: date | None = None, with_adhesions_count: bool = True
-    ) -> Self:
+    def with_procedures_principales(self, *, avant: date | None = None) -> Self:
         procedures_principales = (
             Procedure.objects.with_concatenated_topics_as_string()
             .with_events(avant=avant)
             .filter(parente=None, archived=False)
         )
-        if not with_adhesions_count:
-            procedures_principales = procedures_principales.without_adhesions_count()
 
         return self.prefetch_related(
             models.Prefetch(

--- a/django/docurba/core/views.py
+++ b/django/docurba/core/views.py
@@ -27,7 +27,7 @@ def api_perimetres(request: HttpRequest) -> HttpResponse:
 
     communes = Commune.objects.only(
         "id", "type", "departement"
-    ).with_procedures_principales(avant=avant, with_adhesions_count=False)
+    ).with_procedures_principales(avant=avant)
     if departement := request.GET.get("departement"):
         communes = communes.filter(departement__code_insee=departement)
 

--- a/django/tests/core/test_views.py
+++ b/django/tests/core/test_views.py
@@ -24,6 +24,26 @@ from tests.core.factories import (
 )
 
 
+@pytest.mark.parametrize(
+    "view_name",
+    ["api_perimetres", "api_scots", "api_communes"],
+)
+@pytest.mark.django_db
+# NOTE(cms): this should be refactored when Syrupy will be part of the project.
+def test_vaut_PLH_consolide(client: Client, view_name: str) -> None:  # noqa: N802
+    collectivite = CollectiviteFactory()
+    communes = CommuneFactory.create_batch(3)
+    collectivite.adhesions.add(*communes)
+    ProcedureFactory(
+        with_perimetre=communes[1:],
+        doc_type=TypeDocument.PLUIH,
+        with_event=True,
+        with_event__category=EventCategory.APPROUVE,
+    )
+    response = client.get(reverse(view_name))
+    assert response.status_code == 200
+
+
 class TestAPI:
     @pytest.mark.parametrize(
         ("invalid_avant", "path"),
@@ -44,8 +64,8 @@ class TestAPI:
         )
 
 
+@pytest.mark.django_db
 class TestAPIPerimetres:
-    @pytest.mark.django_db
     def test_format_csv(
         self, client: Client, django_assert_num_queries: DjangoAssertNumQueries
     ) -> None:
@@ -81,7 +101,6 @@ class TestAPIPerimetres:
     @pytest.mark.parametrize(
         ("is_filtering", "expected_lignes"), [(False, 2), (True, 1)]
     )
-    @pytest.mark.django_db
     def test_filtre_par_department(
         self,
         is_filtering: bool,  # noqa: FBT001
@@ -109,7 +128,6 @@ class TestAPIPerimetres:
         reader = DictReader(response.content.decode().splitlines())
         assert len(list(reader)) == expected_lignes
 
-    @pytest.mark.django_db
     @pytest.mark.parametrize(
         ("avant", "opposable"),
         [


### PR DESCRIPTION
Commit 4f32cb2bab551b5d4db021e287619e0244629fb8 introduced a
bug leading to a 500 when calling the Périmètres API.
