### PR TITLE
Ajuster le lien de retour vers une collectivité aux droits de l'utilisateur

### DIFF
--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -342,7 +342,12 @@ export default
       return this.enrichedEvents.map(e => e.attachements).flat().filter(e => e)
     },
     backToCollectivite () {
-      if (this.$user.id && this.$user.profile && this.$user.canViewDDTLayout()) {
+      if (
+        this.$user.id &&
+        this.$user.profile &&
+        this.$user.canViewDDTLayout() &&
+        this.$user.canViewSectionCollectivites({ departement: this.collectivite.departementCode })
+      ) {
         return `/ddt/${this.collectivite.departementCode}/collectivites/${this.collectivite.code}/${this.collectivite.code.length > 5 ? 'epci' : 'commune'}`
       } else {
         return `/collectivites/${this.collectivite.code}`


### PR DESCRIPTION
Sur la page `/frise/<procedureId>` on a un lien de retour vers la collectivité.
On peut accéder à cette page via la recherche de la page d'accueil en cliquant ensuite sur une feuille de route.
En tant qu'utilisateur `ppa` on a le droit de voir les collectivités de `/ddt/<departementId/collectivites/<collectiviteId>/commune` mais seulement pour notre département.
Le lien de retour était construit en vérifiant si on avait le droit d'accéder aux communes en `/ddt/...` de manière générale mais sans vérifier si on avait le droit accéder à celles de ce département, ce qui provoquait une redirection quand on cliquait sur le lien.
Pour corriger ça, cette PR ajoute une vérification des droits liés au département à la création de ce lien.