### PR TITLE
Gérer les emails avec des majuscules dans le partage de procédure

### DIFF
--- a/nuxt/pages/frise/_procedureId/index.vue
+++ b/nuxt/pages/frise/_procedureId/index.vue
@@ -300,7 +300,9 @@ export default
       console.log('this.$user.profile: ', this.$user)
       if (this.$user.profile?.is_admin) { return true }
       if (this.procedure.shareable) {
-        return this.collaborators.some(e => e.email === this.$user.email) || this.$user.profile.is_admin
+        const userEmail = this.$user.email.toLowerCase()
+
+        return this.collaborators.some(e => e.email.toLowerCase() === userEmail) || this.$user.profile.is_admin
       } else {
         if (!this.$user.id || !this.$user.profile?.verified) { return false }
 


### PR DESCRIPTION
Si on partageait une procédure en utilisant des majuscules dans l'email, la procédure était bien partagée à la personne mais la vérification des droits échouait vu qu'on avait une majuscule dans le champs `user_email` de la table `projects_sharing` mais que l'email dans le profil de l'utilisateur était en minuscules.
Pour corriger ça, cette PR compare les valeurs en minuscules au moment de la vérification des droits.