### PR TITLE
Recréer la colonne code des collectivités depuis le frontend

### DIFF
--- a/nuxt/components/VCollectivitesAutocomplete.vue
+++ b/nuxt/components/VCollectivitesAutocomplete.vue
@@ -121,11 +121,11 @@ export default {
       if (this.selectedDepartement) {
         this.loading = true
         try {
-          const groupements = await this.$djangoApi.get('/collectivites/', {
+          const groupements = (await this.$djangoApi.get('/collectivites/', {
             departement: this.selectedDepartement.code_departement,
             without_communes: true,
-            competence: ['plan', 'schema'],
-          })
+            competence: ['plan', 'schema']
+          })).map(groupement => ({ ...groupement, code: groupement.codeInsee || groupement.siren }))
           const communes = await this.$djangoApi.get('/communes/', {
             departement: this.selectedDepartement.code_departement,
             type: 'COM'

--- a/nuxt/pages/ddt/_departement/procedures/index.vue
+++ b/nuxt/pages/ddt/_departement/procedures/index.vue
@@ -271,7 +271,8 @@ export default {
         competence: ['plan', 'schema']
       })
 
-      const [rawProcedures, communes, groupements] = await Promise.all([promProcedures, promCommunes, promGroupements])
+      const [rawProcedures, communes, rawGroupements] = await Promise.all([promProcedures, promCommunes, promGroupements])
+      const groupements = rawGroupements.map(groupement => ({ ...groupement, code: groupement.codeInsee || groupement.siren }))
       this.rawProcedures = rawProcedures.map((e) => {
         let collectivitePorteuse
         if (e.perimetre.length > 1) {


### PR DESCRIPTION
La colonne `code` n'existe plus dans l'API django des collectivités

En attendant de nettoyer le front, on recréé cette colonne dans le front en se basant sur le colonnes `codeInsee` et `siren`