### PR TITLE
Convertir les descriptions des évènements et procédures en markdown

### DIFF
--- a/nuxt/components/Dashboard/DUProcedureItem.vue
+++ b/nuxt/components/Dashboard/DUProcedureItem.vue
@@ -44,9 +44,7 @@
         <p v-if="procedure.topics">
           <ProceduresTopicChips :topics="procedure.topics" />
         </p>
-        <p v-if="procedure.topics__other__comment">
-          {{ procedure.topics__other__comment }}
-        </p>
+        <nuxt-content v-if="topicsOtherComment" :document="topicsOtherComment" />
       </v-col>
       <v-col v-if="procedure.comment_from_sudocuh && $user.canViewProcedureCommentFromSudocuh()" cols="12" class="pb-0">
         <v-divider />
@@ -156,6 +154,10 @@ export default {
   computed: {
     isCommunal () {
       return this.procedure.procedures_perimetres.length === 1
+    },
+    topicsOtherComment () {
+      return this.procedure.topics__other__comment &&
+        { body: this.$md.compile(this.procedure.topics__other__comment) }
     }
   },
   methods: {

--- a/nuxt/components/Frise/EventCard.vue
+++ b/nuxt/components/Frise/EventCard.vue
@@ -57,9 +57,7 @@
           </div>
         </v-card-title>
         <v-card-text>
-          <div v-if="event.commentaire || event.description">
-            {{ event.commentaire || event.description }}
-          </div>
+          <nuxt-content v-if="description" :document="description" />
 
           <div v-if="event.attachements?.length" class="mt-4">
             <v-chip
@@ -131,6 +129,11 @@ export default {
   computed: {
     creator () {
       return this.$utils.formatEventProfileToCreator(this.event)
+    },
+    description () {
+      const descriptionString = this.event.commentaire || this.event.description
+
+      return descriptionString && { body: this.$md.compile(descriptionString) }
     },
     formatDate () {
       return this.$dayjs(this.event.date_iso).format('DD/MM/YYYY')

--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -58,7 +58,12 @@
         <v-row>
           <v-col v-if="topicOtherCommentSelected" cols="6" class="pt-0 pb-2">
             <validation-provider v-slot="{ errors }" name="Details de la procédure" rules="required">
-              <v-text-field v-model="topicOtherComment" :error-messages="errors" filled label="Description de l’objet de la procédure" />
+              <v-textarea
+                v-model="topicOtherComment"
+                :error-messages="errors"
+                filled
+                label="Description de l’objet de la procédure"
+              />
             </validation-provider>
           </v-col>
         </v-row>

--- a/nuxt/components/Procedures/UpdateForm.vue
+++ b/nuxt/components/Procedures/UpdateForm.vue
@@ -26,7 +26,12 @@
         <v-row>
           <v-col v-if="topicOtherCommentSelected" cols="6" class="pt-0 pb-2">
             <validation-provider v-slot="{ errors }" name="Details de la procédure" rules="required">
-              <v-text-field v-model="topicOtherComment" :error-messages="errors" filled label="Description de l’objet de la procédure" />
+              <v-textarea
+                v-model="topicOtherComment"
+                :error-messages="errors"
+                filled
+                label="Description de l’objet de la procédure"
+              />
             </validation-provider>
           </v-col>
         </v-row>

--- a/nuxt/plugins/mdParser.js
+++ b/nuxt/plugins/mdParser.js
@@ -6,9 +6,23 @@ import rehypeSanitize from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
 import rehypeParse from 'rehype-parse'
 import rehypeMinifyWhitespace from 'rehype-minify-whitespace'
+import visit from 'unist-util-visit'
 
 import jsonCompiler from '@nuxt/content/parsers/markdown/compilers/json.js'
 import { defaultSchema } from '@/assets/sanitizeSchema.js'
+
+function rehypeExternalLinks () {
+  return function (tree) {
+    visit(tree, 'element', function (node) {
+      if (node.tagName === 'a') {
+        Object.assign(node.properties, {
+          rel: 'nofollow noopener noreferrer',
+          target: '_blank'
+        })
+      }
+    })
+  }
+}
 
 // TODO: This pugin should be used to clean a lot of deplucated code.
 // ALso, this plugin should have 2 mode one that send a JSON content and an other that send an HTML String
@@ -18,6 +32,7 @@ export default (_, inject) => {
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
     .use(rehypeSanitize, defaultSchema)
+    .use(rehypeExternalLinks)
     .use(rehypeStringify)
     .use(jsonCompiler)
 


### PR DESCRIPTION
Avant :
<img width="497" height="160" alt="event-description-raw" src="https://github.com/user-attachments/assets/fd2626fd-bd7f-4603-9491-7664e5a7a1c6" />
<img width="413" height="130" alt="description-before" src="https://github.com/user-attachments/assets/9d650009-58b2-456a-9a18-e5137df242a7" />
<img width="423" height="69" alt="description-display-before" src="https://github.com/user-attachments/assets/66049dd3-bf8b-45ff-8450-30f2f2bd9ece" />

Après :
<img width="499" height="160" alt="event-description-markdown" src="https://github.com/user-attachments/assets/cabbeed8-7ec7-46e6-b55d-0017f31c425f" />
<img width="416" height="241" alt="description-raw" src="https://github.com/user-attachments/assets/923e13d7-e0b1-4b4e-a984-604204b657e8" />
<img width="170" height="151" alt="description-display-after" src="https://github.com/user-attachments/assets/0f6044e1-7193-4108-b787-bb43bbca94b9" />
