### PR TITLE
Automatiser la commande pour lier les évènements à leur type

### DIFF
--- a/django/bin/clock.sh
+++ b/django/bin/clock.sh
@@ -14,6 +14,9 @@ IFS=$'\n\t'
 
 while true; do
   current_time=$(date +%H:%M)
+  if [[ "$current_time" == "00:23" ]]; then
+    django-admin link_events_with_event_types
+  fi
   # UTC
   if [[ "$current_time" == "00:43" ]]; then
     echo "☕ Il est ${current_time} ! C'est l'heure de la sauvegarde !"


### PR DESCRIPTION
Avant de déployer cette PR en production, il faut impérativement lancer manuellement la commande au moins une fois

- [x] Lancement manuel de la commande dans l'environnement de démo
- [x] Lancement manuel de la commande dans l'environnement de production