### PR TITLE
Amélioration d'une suite de tests

### DIFF
--- a/django/tests/core/management/commands/test_link_events_with_event_types.py
+++ b/django/tests/core/management/commands/test_link_events_with_event_types.py
@@ -1,8 +1,18 @@
 import pytest
 from django.core.management import call_command
 
-from docurba.core.models import Event, EventType, TypeDocument
-from docurba.users.models import User
+from docurba.core.models import (
+    Collectivite,
+    Commune,
+    Departement,
+    Event,
+    EventType,
+    Procedure,
+    Region,
+    TypeDocument,
+)
+from docurba.history.models import EventSnapshot
+from docurba.users.models import Profile, User
 from tests.core.factories import EventFactory, EventTypeFactory
 
 MAPPINGS = [
@@ -39,15 +49,21 @@ MAPPINGS = [
 
 @pytest.fixture
 def clear_data() -> None:
-    call_command(
-        "flush",
-        verbosity=0,
-        interactive=False,
-        reset_sequences=False,
-        allow_cascade=True,
-        inhibit_post_migrate=True,
-    )
-    User.objects.all().delete()  # Why flush dont truncate user table ?
+    yield
+    models = [
+        Collectivite,
+        Procedure,
+        Event,
+        User,
+        Profile,
+        EventType,
+        Commune,
+        Departement,
+        Region,
+        EventSnapshot,
+    ]
+    for model in models:
+        model.objects.all().delete()
 
 
 def _event_types_args(mapping: tuple) -> tuple:


### PR DESCRIPTION
Cette suite de test crée des objets qui ne sont pas supprimés à la fin mais, étrangement, la CI ne l'avait pas repéré et tout passe chez Romain. Les autres tests cassent car il existe déjà des objets en base. Cette commande de gestion étant voué à disparaître dans quelques semaines, cela ne vaut pas la peine d'investir du temps pour trouver l'origine du souci.
J'ai remplacé le `flush` par une liste de modèles à supprimer car c'est bien plus rapide. J'ai également hésité à utiliser `ContentType` mais nous devons conserver les `Topic` et `EventType` qui sont créés automatiquement avec le signal `post_migrate`.
