### PR TITLE
Récupérer les profils des collaborateurs de façon insensible à la casse

### DIFF
--- a/nuxt/plugins/sharing.js
+++ b/nuxt/plugins/sharing.js
@@ -111,7 +111,7 @@ export default ({ app, $supabase, $utils, $user, $analytics }, inject) => {
       console.log('collabsData: ', collabsData, ' procedure.project_id: ', procedure.project_id)
       const emails = _.uniqBy(collabsData, e => e.user_email).map(e => e.user_email)
 
-      const { data: profilesData, error: errorProfiles } = await $supabase.from('profiles').select('*').in('email', emails)
+      const { data: profilesData, error: errorProfiles } = await $supabase.from('profiles').select('*').ilikeAnyOf('email', emails)
       if (errorCollabs) { console.log('errorProfiles: ', errorProfiles) }
       const allCollaborators = [...profilesData ?? [], ...legacyCollabs ?? []]
       const formattedProfiles = allCollaborators.map((e) => {
@@ -121,7 +121,9 @@ export default ({ app, $supabase, $utils, $user, $analytics }, inject) => {
         return $utils.formatProfileToCreator(e)
       })
 
-      const noProfilesCollabs = emails.filter(e => !profilesData.find(prof => prof.email === e)).map(e => ($utils.formatProfileToCreator({ email: e })))
+      const profilesEmails = profilesData.map(profile => profile.email && profile.email.toLowerCase())
+      const noProfilesCollabs = emails.filter(e => !!e && !profilesEmails.includes(e.toLowerCase()))
+        .map(e => ($utils.formatProfileToCreator({ email: e })))
       const finalCollabs = [...noProfilesCollabs, ...formattedProfiles]
       const uniqFinalCollabs = _.uniqBy(finalCollabs, e => e.email)
       return uniqFinalCollabs


### PR DESCRIPTION
Avant :
<img width="303" height="82" alt="colaborator-before" src="https://github.com/user-attachments/assets/03937e87-f08f-4bd9-b714-b3acd6841877" />

Après :
<img width="224" height="102" alt="colaborator-after" src="https://github.com/user-attachments/assets/5826df7c-cbc4-49a6-bd1e-659cf8b921ff" />
