### PR TITLE
Gérer une longue liste de codes siren sur l'endpoint /collectivites

### DIFF
--- a/nuxt/plugins/collectivite.js
+++ b/nuxt/plugins/collectivite.js
@@ -14,7 +14,27 @@ export async function getCollectivite (api, id, params) {
 }
 
 export async function listCollectivites (api, params) {
-  return (await api.get('/api-internes/collectivites/', params)).map(parseCollectivite)
+  if (!params.codes_siren || params.codes_siren.length < 100) {
+    return (await api.get('/api-internes/collectivites/', params)).map(parseCollectivite)
+  }
+
+  const collectivitesQueries = []
+
+  for (let i = 0; i < params.codes_siren.length; i += 100) {
+    collectivitesQueries.push(api.get('/api-internes/collectivites/', {
+      ...params,
+      codes_siren: params.codes_siren.slice(i, i + 100)
+    }))
+  }
+
+  return (await Promise.all(collectivitesQueries))
+    .flatMap(c => c.map(parseCollectivite))
+    .sort((a, b) => {
+      const aCode = Number(a.code)
+      const bCode = Number(b.code)
+
+      return aCode === bCode ? 0 : aCode > bCode ? 1 : -1
+    })
 }
 
 function parseCollectivite (collectivite) {


### PR DESCRIPTION
Quand on a trop de `codes_siren` en paramètre de l'endpoint `/collectivites`, on a une erreur :
<img width="268" height="104" alt="bad-request" src="https://github.com/user-attachments/assets/d152c897-e919-4259-9d68-4f14184c9f28" />

Pour éviter ce problème, cette PR découpe les appels avec de nombreux `codes_siren` en plusieurs requêtes