### PR TITLE
Utiliser les bonnes données pour l'export des communes

### DIFF
--- a/nuxt/pages/ddt/_departement/collectivites/index.vue
+++ b/nuxt/pages/ddt/_departement/collectivites/index.vue
@@ -657,7 +657,7 @@ export default {
       })
 
       this.exportingCommunes = true
-      const { data } = await this.$djangoApi.get('/api/communes', {
+      const data = await this.$djangoApi.get('/api/communes', {
         departement: departementCode
       })
 


### PR DESCRIPTION
Le plugin `djangoApi` se charge déjà d'extraire la propriété `data` depuis la réponse de l'API, du coup ici on le faisait une seconde fois ce qui retournait `undefined`