### PR TITLE
Tests : ajout du profile_id au User Django dans les fixtures

### DIFF
--- a/django/tests/conftest.py
+++ b/django/tests/conftest.py
@@ -5,6 +5,8 @@ from django.test import Client
 from pytest_django import DjangoDbBlocker
 from rest_framework.test import APIClient
 
+from tests.users.factories import ProfileFactory
+
 
 @pytest.fixture
 def api_client() -> APIClient:
@@ -21,16 +23,18 @@ def admin_session_client(django_db_blocker: DjangoDbBlocker | None) -> Client:
     client = Client()
     UserModel = get_user_model()  # noqa: N806
     email = "admin@test.com"
-    data = {
-        "email": email,
-        "password": "password",
-        "username": email,
-    }
 
     with django_db_blocker.unblock():
         try:
             user = UserModel.objects.get(email=email)
         except UserModel.DoesNotExist:
+            profile = ProfileFactory(email=email)
+            data = {
+                "email": email,
+                "password": "password",
+                "username": email,
+                "profile_id": profile.user_id,
+            }
             user = UserModel.objects.create_superuser(**data)
         client.force_login(user)
 
@@ -49,11 +53,6 @@ def staff_session_client(django_db_blocker: DjangoDbBlocker | None) -> Client:
     client = Client()
     UserModel = get_user_model()  # noqa: N806
     email = "staff@test.com"
-    data = {
-        "email": email,
-        "password": "password",
-        "username": email,
-    }
 
     with django_db_blocker.unblock():
         write_group, _ = Group.objects.get_or_create(name="write")
@@ -72,6 +71,13 @@ def staff_session_client(django_db_blocker: DjangoDbBlocker | None) -> Client:
         try:
             user = UserModel.objects.get(email=email)
         except UserModel.DoesNotExist:
+            profile = ProfileFactory(email=email)
+            data = {
+                "email": email,
+                "password": "password",
+                "username": email,
+                "profile_id": profile.user_id,
+            }
             user = UserModel.objects.create_user(**data, is_staff=True)
 
         user.groups.add(write_group)

--- a/django/tests/core/management/commands/test_link_events_with_event_types.py
+++ b/django/tests/core/management/commands/test_link_events_with_event_types.py
@@ -12,7 +12,7 @@ from docurba.core.models import (
     TypeDocument,
 )
 from docurba.history.models import EventSnapshot
-from docurba.users.models import Profile, SupabaseUser
+from docurba.users.models import Profile, SupabaseUser, User
 from tests.core.factories import EventFactory, EventTypeFactory
 
 MAPPINGS = [
@@ -59,8 +59,9 @@ def clear_data() -> None:
         Collectivite,
         Departement,
         Region,
-        Profile,
+        User,
         SupabaseUser,
+        Profile,
     ]
     for model in models:
         model.objects.all().delete()

--- a/django/tests/users/test_admin.py
+++ b/django/tests/users/test_admin.py
@@ -3,6 +3,7 @@ from django.test import Client
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 
+from docurba.users.models import Profile, User
 from tests.users.factories import SupabaseUserFactory
 
 
@@ -29,3 +30,20 @@ class TestSupabaseUserAdmin:
             follow=True,
         )
         assertContains(response, "Nouveau mot de passe :")
+
+    # Make sure you remove the test database first
+    # because the Django user is not recreated between
+    # tests.
+    def test_staff_session_client(self, staff_session_client: Client) -> None:
+        django_user = User.objects.get(pk=staff_session_client.session["_auth_user_id"])
+        assert (
+            django_user.profile_id
+            == Profile.objects.get(email=django_user.email).user_id
+        )
+
+    def test_admin_session_client(self, admin_session_client: Client) -> None:
+        django_user = User.objects.get(pk=admin_session_client.session["_auth_user_id"])
+        assert (
+            django_user.profile_id
+            == Profile.objects.get(email=django_user.email).user_id
+        )

--- a/django/tests/users/test_models.py
+++ b/django/tests/users/test_models.py
@@ -1,25 +1,11 @@
 import pytest
 from django.db import connection, transaction
 
-from docurba.users.models import Profile, SupabaseUser
-
-from .factories import ProfileFactory, SupabaseUserFactory
+from .factories import SupabaseUserFactory
 
 
 @pytest.mark.django_db
 class TestSupabaseUserModel:
-    def test_user_creation(self) -> None:
-        """La table users n'est pas dans le schéma par défaut (public) mais dans `auth`.
-
-        Les schémas PostgreSQL ne semblent pas être très bien pris en charge nativement par Django.
-        Nous aurions probablement pu mettre en place un routeur de DB (Database Router) pour rester
-        en cohérence avec l'architecture de Django mais cette table disparaîtra avec Supabase.
-        Elle existe uniquement car Supabase l'utilise dans sa fonctionnalité SSO.
-        Pour le moment, et uniquement pour les tests, créons un schéma `auth`.
-        """
-        SupabaseUserFactory()
-        assert SupabaseUser.objects.count() == 1
-
     def test_update_password(self) -> None:
         user = SupabaseUserFactory()
         assert not user.encrypted_password
@@ -32,17 +18,9 @@ class TestSupabaseUserModel:
         with connection.cursor() as cursor, transaction.atomic():
             cursor.execute(
                 """
-                    SELECT (encrypted_password = crypt(%s, encrypted_password)) AS encrypted_password FROM auth.users;
+                    SELECT (encrypted_password = crypt(%s, encrypted_password)) AS encrypted_password FROM auth.users where id=%s;
                 """,
-                [password],
+                [password, user.id],
             )
             row = cursor.fetchone()
         assert row[0]
-
-
-@pytest.mark.django_db
-class TestProfileModel:
-    def test_profile_creation(self) -> None:
-        profile = ProfileFactory(other_poste=["rédacteur", "maire"])
-        assert Profile.objects.count() == 1
-        assert profile.other_poste == ["rédacteur", "maire"]


### PR DESCRIPTION
Ajout d'un `Profile` à la _fixture_ Pytest pour tester que l'archivage d'un événement enregistre bien l'ID de l'utilisateur connecté.
J'ai dû changer l'ordre de suppression des modèles dans les tests de la management command car on n'a pas encore de CASCADE (et ça ne me semblerait pas souhaitable dans l'immédiat).

J'ai dû relancer la CI deux fois à cause de tests bagotants (déjà connus).

À toi de voir si tu veux ajouter également un profil à l'autre fixture. Ça me semblerait cohérent.
