### PR TITLE
Django : ne pas utiliser le fomatter JSON en test

### DIFF
--- a/django/config/settings/test.py
+++ b/django/config/settings/test.py
@@ -3,6 +3,9 @@ from config.settings.base import *  # NOSONAR (S2208)
 
 DOCURBA_ENVIRONMENT = DocurbaEnvironment.TEST
 
+# Don't use json formatter in dev
+del LOGGING["handlers"]["console"]["formatter"]
+
 STORAGES["staticfiles"]["BACKEND"] = (
     "django.contrib.staticfiles.storage.StaticFilesStorage"
 )


### PR DESCRIPTION
Cela brouille le message mais, surtout, c'est complètement inutile.
