### PR TITLE
Django settings : utiliser le fuseau horaire français

### DIFF
--- a/django/config/settings/base.py
+++ b/django/config/settings/base.py
@@ -127,8 +127,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
 LANGUAGE_CODE = "fr-fr"
-
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/Paris"
 
 
 # Static files (CSS, JavaScript, Images)

--- a/django/config/settings/base.py
+++ b/django/config/settings/base.py
@@ -130,10 +130,6 @@ LANGUAGE_CODE = "fr-fr"
 
 TIME_ZONE = "UTC"
 
-USE_I18N = True
-
-USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/


### PR DESCRIPTION
Les résultats affichés dans l'admin Django l'étaient en UTC alors que
nos utilisateurs sont dans le fuseau Europe/Paris. Il y avait un décalage.
