### PR TITLE
Gérer les emails mal formés dans le partage de procédure

### DIFF
--- a/nuxt/plugins/sharing.js
+++ b/nuxt/plugins/sharing.js
@@ -109,7 +109,11 @@ export default ({ app, $supabase, $utils, $user, $analytics }, inject) => {
 
       if (errorCollabs) { console.log('errorCollabs: ', errorCollabs) }
       console.log('collabsData: ', collabsData, ' procedure.project_id: ', procedure.project_id)
-      const emails = _.uniqBy(collabsData, e => e.user_email).map(e => e.user_email)
+      const emails = _.uniq(collabsData.flatMap(
+        d => d.user_email
+          ? d.user_email.split(';').map(e => e.replaceAll('"', '').trim().toLowerCase())
+          : []
+      ))
 
       const { data: profilesData, error: errorProfiles } = await $supabase.from('profiles').select('*').ilikeAnyOf('email', emails)
       if (errorCollabs) { console.log('errorProfiles: ', errorProfiles) }


### PR DESCRIPTION
Cette PR permet de gérer le partage de mails mal formés, par exemple
`one@example.com ;two@example.com\t;three@example.com"`

- Séparation des mails
- Retrait des `"`
- Retrait des espaces et des tabs