### PR TITLE
Ajout de filtres à l'API interne Collectivité : `trouvable` et `codes_insee`

### DIFF
--- a/django/docurba/core/enums.py
+++ b/django/docurba/core/enums.py
@@ -102,6 +102,17 @@ class TypeCollectivite(models.TextChoices):
         return {member.value: member for member in cls if member in enums}
 
     @classmethod
+    def epci_fiscalite_propre(cls: models.TextChoices) -> dict:
+        enums = [
+            cls.CC,
+            cls.CA,
+            cls.CU,
+            cls.MET69,
+            cls.METRO,
+        ]
+        return {member.value: member for member in cls if member in enums}
+
+    @classmethod
     def communes(cls: models.TextChoices) -> dict:
         enums = [
             cls.COM,

--- a/django/docurba/internal_api/filters.py
+++ b/django/docurba/internal_api/filters.py
@@ -59,6 +59,10 @@ class CollectiviteFilter(DepartementRegionFilterSet):
         label="Codes SIREN",
         field_name="siren",
     )
+    codes_insee = NoValidationMultipleFilter(
+        label="Codes INSEE",
+        field_name="code_insee",
+    )
     without_communes = filters.BooleanFilter(
         label="Sans les communes", method="_without_communes"
     )
@@ -73,6 +77,7 @@ class CollectiviteFilter(DepartementRegionFilterSet):
         fields = (
             "type",
             "codes_siren",
+            "codes_insee",
             "competence",
             *DepartementRegionFilterSet.fields,
         )

--- a/django/docurba/internal_api/filters.py
+++ b/django/docurba/internal_api/filters.py
@@ -57,7 +57,7 @@ class CollectiviteFilter(DepartementRegionFilterSet):
     type = filters.MultipleChoiceFilter(field_name="type", choices=TypeCollectivite)
     codes_siren = NoValidationMultipleFilter(
         label="Codes SIREN",
-        field_name="code_insee_unique",
+        field_name="siren",
     )
     without_communes = filters.BooleanFilter(
         label="Sans les communes", method="_without_communes"
@@ -102,7 +102,7 @@ class CommuneFilter(DepartementRegionFilterSet):
     type = filters.MultipleChoiceFilter(
         field_name="type", choices=TypeCollectivite.communes()
     )
-    code = NoValidationMultipleFilter(field_name="code_insee_unique")
+    code = NoValidationMultipleFilter(field_name="code_insee")
 
     class Meta:
         model = Commune

--- a/django/docurba/internal_api/filters.py
+++ b/django/docurba/internal_api/filters.py
@@ -71,6 +71,7 @@ class CollectiviteFilter(DepartementRegionFilterSet):
         method="_filter_competences",
         choices=COMPETENCES_CHOICES,
     )
+    trouvable = filters.BooleanFilter(label="trouvable", method="_searchable")
 
     class Meta:
         model = Collectivite
@@ -101,6 +102,21 @@ class CollectiviteFilter(DepartementRegionFilterSet):
             return queryset
         commune_types = TypeCollectivite.communes()
         return queryset.exclude(type__in=commune_types)
+
+    def _searchable(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        # NOTE(cms): this logic is borrowed from the convertCSVInputsToReferentiels.js script,
+        # in the docurba-geo repository,
+        # which was used to create the JSON files overused everywhere in the project.
+        # https://github.com/MTES-MCT/docurba-geo/blob/main/convertCSVInputsToReferentiels.js#L248-L263
+        # I think it may be called `Collectivite.can_create_procedure` but I'm not sure yet
+        # if it's the right name. That's why it's here for the moment, and not in the model.
+        if not value:
+            return queryset
+        return queryset.filter(
+            Q(competence_plan=True)
+            | Q(competence_schema=True)
+            | Q(type__in=["COM", *TypeCollectivite.epci_fiscalite_propre()])
+        )
 
 
 class CommuneFilter(DepartementRegionFilterSet):

--- a/django/tests/internal_api/test_views/__snapshots__/test_views.ambr
+++ b/django/tests/internal_api/test_views/__snapshots__/test_views.ambr
@@ -174,6 +174,15 @@
 # name: TestCollectivitesAPI.test_list_filters[no_filter]
   list([
     dict({
+      'codeInsee': '30032',
+      'departementCode': '30',
+      'intercommunaliteCode': '',
+      'intitule': 'Beaucaire',
+      'regionCode': '76',
+      'siren': '',
+      'type': 'COM',
+    }),
+    dict({
       'codeInsee': '',
       'departementCode': '84',
       'intercommunaliteCode': '',

--- a/django/tests/internal_api/test_views/__snapshots__/test_views.ambr
+++ b/django/tests/internal_api/test_views/__snapshots__/test_views.ambr
@@ -105,6 +105,19 @@
     }),
   ])
 # ---
+# name: TestCollectivitesAPI.test_list_filters[codes_insee]
+  list([
+    dict({
+      'codeInsee': '30032',
+      'departementCode': '30',
+      'intercommunaliteCode': '',
+      'intitule': 'Beaucaire',
+      'regionCode': '76',
+      'siren': '',
+      'type': 'COM',
+    }),
+  ])
+# ---
 # name: TestCollectivitesAPI.test_list_filters[many_codes_siren]
   list([
     dict({

--- a/django/tests/internal_api/test_views/test_views.py
+++ b/django/tests/internal_api/test_views/test_views.py
@@ -1,3 +1,5 @@
+import functools
+import random
 from urllib.parse import urlencode
 
 import pytest
@@ -139,6 +141,47 @@ class TestCollectivitesAPI:
 
         assert response.status_code == 200
         assert response.json()["results"] == snapshot()
+
+    @pytest.mark.parametrize(
+        ("factory_params"),
+        [
+            pytest.param(
+                {"type": TypeCollectivite.COM},
+                id="commune",
+            ),
+            pytest.param(
+                {
+                    "type": functools.partial(
+                        random.choice,
+                        seq=list(TypeCollectivite.epci_fiscalite_propre()),
+                    )
+                },
+                id="epci_fiscalite_propre",
+            ),
+            pytest.param(
+                {"type": TypeCollectivite.SIVOM, "competence_plan": True},
+                id="competence_plan",
+            ),
+            pytest.param(
+                {"type": TypeCollectivite.SIVOM, "competence_schema": True},
+                id="competence_schema",
+            ),
+        ],
+    )
+    def test_trouvable(self, factory_params: dict, api_client: APIClient) -> None:
+        collectivite = CollectiviteFactory(
+            **factory_params,
+        )
+        CollectiviteFactory(
+            competence_plan=False, competence_schema=False, type=TypeCollectivite.SIVOM
+        )
+        url = f"{reverse('internal_api:collectivites-list')}?{urlencode({'trouvable': 'true'})}"
+        with assertNumQueries(BASE_QUERIES_COUNT + 1):
+            response = api_client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert len(response.json()["results"]) == 1
+        assert response.json()["results"][0]["siren"] == collectivite.siren
 
     @pytest.mark.parametrize(
         ("query_params"),

--- a/django/tests/internal_api/test_views/test_views.py
+++ b/django/tests/internal_api/test_views/test_views.py
@@ -87,6 +87,7 @@ class TestCollectivitesAPI:
             departement__code_insee="30",
             nom="Groupement 3",
         )
+        CommuneFactory(for_snapshot=True)
 
         url = f"{reverse('internal_api:collectivites-list')}?{urlencode(query_params, doseq=True)}"
         with assertNumQueries(expected_num_queries):

--- a/django/tests/internal_api/test_views/test_views.py
+++ b/django/tests/internal_api/test_views/test_views.py
@@ -60,6 +60,11 @@ class TestCollectivitesAPI:
                 BASE_QUERIES_COUNT + 1,
                 id="many_codes_siren",
             ),
+            pytest.param(
+                {"codes_insee": ["30032"]},
+                BASE_QUERIES_COUNT + 1,
+                id="codes_insee",
+            ),
         ],
     )
     def test_list_filters(

--- a/nuxt/components/Dashboard/PerimetreDialog.vue
+++ b/nuxt/components/Dashboard/PerimetreDialog.vue
@@ -77,9 +77,8 @@ export default {
   watch: {
     async dialog (newVal) {
       if (newVal) {
-        this.fullPerimetre = await this.$collectiviteApi.list({
-          codes_siren: this.perimetre.map(y => y.collectivite_code)
-        })
+        this.fullPerimetre = await this.$collectiviteApi
+          .listFromCodes(this.perimetre.map(y => y.collectivite_code))
       }
     }
   }

--- a/nuxt/plugins/collectivite.js
+++ b/nuxt/plugins/collectivite.js
@@ -5,6 +5,9 @@ export default ({ $djangoApi }, inject) => {
     },
     list (params) {
       return listCollectivites($djangoApi, params)
+    },
+    listFromCodes (codes, params) {
+      return listCollectivitesFromCodes($djangoApi, codes, params)
     }
   })
 }
@@ -14,27 +17,52 @@ export async function getCollectivite (api, id, params) {
 }
 
 export async function listCollectivites (api, params) {
-  if (!params.codes_siren || params.codes_siren.length < 100) {
+  if (
+    (!params.codes_insee || params.codes_insee.length < 100) &&
+    (!params.codes_siren || params.codes_siren.length < 100)
+  ) {
     return (await api.get('/api-internes/collectivites/', params)).map(parseCollectivite)
   }
 
   const collectivitesQueries = []
 
-  for (let i = 0; i < params.codes_siren.length; i += 100) {
-    collectivitesQueries.push(api.get('/api-internes/collectivites/', {
-      ...params,
-      codes_siren: params.codes_siren.slice(i, i + 100)
-    }))
+  if (params.codes_insee) {
+    for (let i = 0; i < params.codes_insee.length; i += 100) {
+      collectivitesQueries.push(api.get('/api-internes/collectivites/', {
+        ...params,
+        codes_insee: params.codes_insee.slice(i, i + 100)
+      }))
+    }
+  }
+  if (params.codes_siren) {
+    for (let i = 0; i < params.codes_siren.length; i += 100) {
+      collectivitesQueries.push(api.get('/api-internes/collectivites/', {
+        ...params,
+        codes_siren: params.codes_siren.slice(i, i + 100)
+      }))
+    }
   }
 
-  return (await Promise.all(collectivitesQueries))
-    .flatMap(c => c.map(parseCollectivite))
-    .sort((a, b) => {
-      const aCode = Number(a.code)
-      const bCode = Number(b.code)
+  return sortCollectivites((await Promise.all(collectivitesQueries)).flatMap(c => c.map(parseCollectivite)))
+}
 
-      return aCode === bCode ? 0 : aCode > bCode ? 1 : -1
-    })
+export async function listCollectivitesFromCodes (api, codes, params = {}) {
+  const inseeCodes = []
+  const sirenCodes = []
+  const collectivitesQueries = []
+
+  codes.forEach((code) => {
+    (code.length > 5 ? sirenCodes : inseeCodes).push(code)
+  })
+
+  if (inseeCodes.length) {
+    collectivitesQueries.push(listCollectivites(api, { ...params, codes_insee: inseeCodes }))
+  }
+  if (sirenCodes.length) {
+    collectivitesQueries.push(listCollectivites(api, { ...params, codes_siren: sirenCodes }))
+  }
+
+  return sortCollectivites((await Promise.all(collectivitesQueries)).flat())
 }
 
 function parseCollectivite (collectivite) {
@@ -42,4 +70,13 @@ function parseCollectivite (collectivite) {
     ...collectivite,
     code: collectivite.codeInsee || collectivite.siren
   }
+}
+
+function sortCollectivites (collectivites) {
+  return [...collectivites].sort((a, b) => {
+    const aCode = Number(a.code)
+    const bCode = Number(b.code)
+
+    return aCode === bCode ? 0 : aCode > bCode ? 1 : -1
+  })
 }

--- a/nuxt/plugins/urbanisator.js
+++ b/nuxt/plugins/urbanisator.js
@@ -53,9 +53,7 @@ export default ({ $collectiviteApi, $supabase, $dayjs }, inject) => {
         collectiviteId
       ])
 
-      const collectivites = await $collectiviteApi.list({
-        codes_siren: collectivitesCodes
-      })
+      const collectivites = await $collectiviteApi.listFromCodes(collectivitesCodes)
 
       procedures.forEach((procedure) => {
         procedure.procedures_perimetres = procedure.procedures_perimetres.map((p) => {


### PR DESCRIPTION
Ajout du filtre `codes_insee` pour chercher des collectivités par code insee. J'ai gardé l'écriture en _snake case_ pour conserver la cohérence avec `codes_siren`.

Ajout du filtre `trouvable` pour regrouper les règles métier des groupements qui peuvent être sélectionnés lors de la création d'une procédure. Pour l'instant, le concept n'est pas assez clair pour moi car les règles sont éparpillées partout.
En revanche, je me suis rendue compte que certains groupements n'étaient plus trouvables sur la page d'accueil depuis l'intégration de l'API interne : les EPCI à fiscalité propre et sans compétence. [Le script qui crée les fichiers JSON](https://github.com/MTES-MCT/docurba-geo/blob/main/convertCSVInputsToReferentiels.js#L248-L263) applique bien cette règle lors de la génération mais nous ne l'avons pas totalement déportée dans Django.

Un groupement trouvable est dans un des cas suivants :
- EPCI à fiscalité propre
- a la compétence plan
- a la compétence schéma
- est de type COM

À ma connaissance, ces règles sont utilisées dans tous les endroits où les groupements sont cherchés sans leur code SIREN ou INSEE.