### PR TITLE
Formulaire de création de procédure secondaire : utiliser une API interne pour fournir les procédures principales

### DIFF
--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -541,10 +541,7 @@ class Procedure(models.Model):
         )
 
     def __str__(self) -> str:
-        return (
-            self.name
-            or f"🤖 {self.type} {self.numero or ''} {self.type_document} {self.collectivite_porteuse}"
-        )
+        return self.name or f"🤖 {self.computed_name}"
 
     def __lt__(self, other: Self) -> bool:
         if self.date_approbation and other.date_approbation:
@@ -555,6 +552,39 @@ class Procedure(models.Model):
 
     def get_absolute_url(self) -> str:
         return f"/frise/{self.pk}"
+
+    @property
+    def computed_name(self) -> str:
+        return self.name or " ".join(
+            part
+            for part in [
+                self.type,
+                self.numero or "",
+                self.type_document,
+                self.perimetre_name,
+            ]
+            if part
+        )
+
+    @property
+    def perimetre_name(self) -> str:
+        # If a prefetch has been made, use it here to avoid N+1 queries.
+        perimetre_qs = (
+            self._prefetched_objects_cache.get("perimetre", self.perimetre.all())
+            if hasattr(self, "_prefetched_objects_cache")
+            else self.perimetre.all()
+        )
+        if perimetre_qs.count() == 1:
+            return perimetre_qs[0].nom
+        if (
+            perimetre_qs.count() > 1
+            and [town.type for town in perimetre_qs].count(CommuneType.COM) == 1
+        ):
+            return ", ".join(
+                f"{town.nom} ({town.type})"
+                for town in sorted(perimetre_qs, key=lambda town: town.type)
+            )
+        return self.collectivite_porteuse.nom if self.collectivite_porteuse else ""
 
     _events_processed = False
 

--- a/django/docurba/internal_api/auth.py
+++ b/django/docurba/internal_api/auth.py
@@ -8,6 +8,7 @@ from supabase import AuthApiError, Client, ClientOptions, create_client
 from docurba.users.models import Session
 
 
+# Should be SessionAuthentication?
 class SupabaseAuthentication(authentication.BaseAuthentication):
     def __init__(self) -> None:
         self.supabase_client: Client = create_client(

--- a/django/docurba/internal_api/filters.py
+++ b/django/docurba/internal_api/filters.py
@@ -11,6 +11,8 @@ from docurba.core.models import (
     Commune,
     Departement,
     EventType,
+    Procedure,
+    ProcedureStatusChoices,
     Region,
     TypeCollectivite,
 )
@@ -134,3 +136,50 @@ class EventTypeFilter(filters.FilterSet):
     class Meta:
         model = EventType
         fields = ("document_type",)
+
+
+class ProcedureFilter(filters.FilterSet):
+    communes_perimetre = NoValidationMultipleFilter(
+        label="communes du périmètre", method="_communes_perimetre"
+    )
+    collectivites_porteuses = NoValidationMultipleFilter(
+        label="collectivités porteuses", method="_collectivites_porteuses"
+    )
+    status = filters.MultipleChoiceFilter(
+        label="Statut selon Nuxt",
+        field_name="status",
+        choices=ProcedureStatusChoices,
+    )
+
+    class Meta:
+        model = Procedure
+        fields = (
+            "is_principale",
+            "status",
+            "communes_perimetre",
+            "collectivites_porteuses",
+        )
+
+    def _collectivites_porteuses(
+        self, queryset: QuerySet, name: str, sirens: list
+    ) -> QuerySet:
+        if not sirens:
+            return queryset
+        if not isinstance(sirens, list):
+            raise ValueError(("%s should be a list.", sirens))  # noqa: TRY004
+        return queryset.filter(
+            Q(collectivite_porteuse__siren__in=sirens)
+            | Q(collectivite_porteuse__code_insee__in=sirens)
+        )
+
+    def _communes_perimetre(
+        self, queryset: QuerySet, name: str, codes_insee: str
+    ) -> QuerySet:
+        if not codes_insee:
+            return queryset
+        if not isinstance(codes_insee, list):
+            raise ValueError(("%s should be a list.", codes_insee))  # noqa: TRY004
+        # Should search in the JSON but we'd like to search several keys.
+        # The actual search only works when there is only one element in the list.
+        #     query = query.contains('current_perimetre', `[{ "inseeCode": "${this.collectivite.code}" }]`)
+        return queryset.filter(perimetre__code_insee__in=codes_insee)

--- a/django/docurba/internal_api/serializers.py
+++ b/django/docurba/internal_api/serializers.py
@@ -2,7 +2,14 @@
 
 from rest_framework import serializers
 
-from docurba.core.models import Collectivite, Commune, EventType
+from docurba.core.models import (
+    Collectivite,
+    Commune,
+    EventType,
+    Procedure,
+    Topic,
+    TypeDocument,
+)
 
 
 class BaseCollectiviteSerializer(serializers.ModelSerializer):
@@ -129,3 +136,53 @@ class EventTypeSerializer(serializers.ModelSerializer):
             "sudocuhName",  # TODO: remove  # noqa: FIX002
         ]
         read_only_fields = fields
+
+
+class TopicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Topic
+        fields = ["name"]
+        read_only_fields = fields
+
+
+class BaseProcedureSerializer(serializers.ModelSerializer):
+    id = serializers.CharField()
+    collectivite_porteuse = CollectiviteSerializer()
+    docType = serializers.ChoiceField(choices=TypeDocument, source="doc_type")
+    startedBeforeHuwartLaw = serializers.BooleanField(
+        source="started_before_huwart_law", default=False
+    )
+    topics = TopicSerializer(many=True)
+    perimetre = CommuneSerializer(many=True)
+
+    class Meta:
+        model = Procedure
+        read_only_fields = [
+            "id",
+            "project_id",
+        ]
+        fields = [
+            *read_only_fields,
+            "collectivite_porteuse",
+            "project_id",
+            "perimetre",
+            "docType",
+            "startedBeforeHuwartLaw",
+            "type",
+            "numero",
+            "name",
+            "status",
+            "topics",
+        ]
+        depth = 4
+
+
+class ProcedureSerializer(BaseProcedureSerializer):
+    parent = BaseProcedureSerializer(source="parente", default="")
+
+    class Meta:
+        model = Procedure
+        fields = [
+            "parent",
+            *BaseProcedureSerializer.Meta.fields,
+        ]

--- a/django/docurba/internal_api/serializers.py
+++ b/django/docurba/internal_api/serializers.py
@@ -154,6 +154,7 @@ class BaseProcedureSerializer(serializers.ModelSerializer):
     )
     topics = TopicSerializer(many=True)
     perimetre = CommuneSerializer(many=True)
+    name = serializers.CharField(source="computed_name")
 
     class Meta:
         model = Procedure

--- a/django/docurba/internal_api/urls.py
+++ b/django/docurba/internal_api/urls.py
@@ -8,5 +8,6 @@ router = routers.DefaultRouter()
 router.register(r"collectivites", views.CollectiviteViewSet, basename="collectivites")
 router.register(r"communes", views.CommuneViewSet, basename="communes")
 router.register(r"types-evenement", views.EventTypeViewSet, basename="event_types")
+router.register(r"procedures", views.ProcedureViewSet, basename="procedures")
 
 urlpatterns = router.urls

--- a/django/docurba/internal_api/views.py
+++ b/django/docurba/internal_api/views.py
@@ -1,12 +1,15 @@
 from django.db import models
 from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
 
-from docurba.core.models import Collectivite, Commune, EventType
+from docurba.core.models import Collectivite, Commune, EventType, Procedure
 from docurba.internal_api import filters as custom_filters
+from docurba.internal_api.auth import SupabaseAuthentication
 from docurba.internal_api.serializers import (
     CollectiviteSerializer,
     CommuneSerializer,
     EventTypeSerializer,
+    ProcedureSerializer,
 )
 
 
@@ -88,3 +91,47 @@ class EventTypeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = EventType.active_objects.all()
     serializer_class = EventTypeSerializer
     filterset_class = custom_filters.EventTypeFilter
+
+
+class ProcedureViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = (
+        Procedure.objects.all()
+        .select_related(
+            "collectivite_porteuse",
+            "collectivite_porteuse__commune",
+            "parente",
+            "parente__collectivite_porteuse",
+            "parente__collectivite_porteuse__commune",
+        )
+        .prefetch_related(
+            "topics",
+            models.Prefetch(
+                "perimetre",
+                Commune.objects.select_related(
+                    "departement",
+                    "departement__region",
+                    "intercommunalite",
+                ),
+            ),
+        )
+        .prefetch_related(
+            "parente__topics",
+            models.Prefetch(
+                "parente__perimetre",
+                Commune.objects.select_related(
+                    "departement",
+                    "departement__region",
+                    "intercommunalite",
+                ),
+            ),
+        )
+        .order_by("id")
+    )
+    authentication_classes = [SupabaseAuthentication]  # noqa: RUF012
+    # https://github.com/django-guardian/django-guardian
+    # https://docs.djangoproject.com/en/6.0/ref/contrib/contenttypes/ for user class
+    permission_classes = [IsAuthenticated]  # noqa: RUF012
+    serializer_class = ProcedureSerializer
+    filterset_class = custom_filters.ProcedureFilter
+
+    # Because the get_object() method is not called, object level permissions from the has_object_permission() method are not applied when creating objects. In order to restrict object creation you need to implement the permission check either in your Serializer class or override the perform_create() method of your ViewSet class.

--- a/django/tests/conftest.py
+++ b/django/tests/conftest.py
@@ -1,16 +1,44 @@
+import contextlib
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.core.handlers.wsgi import WSGIRequest
 from django.test import Client
 from pytest_django import DjangoDbBlocker
 from rest_framework.test import APIClient
 
-from tests.users.factories import ProfileFactory
+from docurba.core.models import Profile
+from tests.users.factories import ProfileFactory, SessionFactory
+
+
+class SupabaseApiClient(APIClient):
+    def request(self, **kwargs: dict) -> WSGIRequest:
+        kwargs["HTTP_SUPABASE-AUTHORIZATION"] = "test-token"
+        return super().request(**kwargs)
 
 
 @pytest.fixture
 def api_client() -> APIClient:
     return APIClient()
+
+
+@pytest.fixture(name="api_client_with_auth")
+def api_client_with_auth_factory() -> None:
+
+    @contextlib.contextmanager
+    def api_client_with_auth(profile: Profile) -> None:
+        session = SessionFactory(user=profile.user)
+
+        with patch("docurba.internal_api.auth.create_client") as create_client:
+            supabase = create_client.return_value
+            supabase.auth.get_claims.return_value = {
+                "claims": {"session_id": session.id, "email": session.user.email}
+            }
+            yield SupabaseApiClient()
+
+    return api_client_with_auth
 
 
 @pytest.fixture(scope="session")

--- a/django/tests/core/factories.py
+++ b/django/tests/core/factories.py
@@ -23,6 +23,7 @@ from docurba.core.models import (
     ProcedureStatusChoices,
     Project,
     Region,
+    Topic,
     TypeCollectivite,
     TypeDocument,
 )
@@ -230,6 +231,7 @@ class ProjectFactory(factory.django.DjangoModelFactory):
 
     class Params:
         for_snapshot = factory.Trait(
+            id=uuid.UUID("fb48c069-33c6-4ed2-9db3-054e99ea7981"),
             name="Projet d'élaboration du PLU de Nantes",
         )
 
@@ -301,6 +303,14 @@ class ProcedureFactory(factory.django.DjangoModelFactory):
             ][0]
 
         EventFactory(procedure=self, type=event_type, **extra)
+
+    @factory.post_generation
+    def with_topics(self, create: bool, extracted: bool, **extra: dict) -> None:  # noqa: FBT001
+        if not create or not extracted:
+            return
+
+        topics = extra.pop("list", None) or Topic.objects.all()[:2]
+        self.topics.add(*topics)
 
 
 class CommuneProcedureFactory(factory.django.DjangoModelFactory):

--- a/django/tests/core/test_models.py
+++ b/django/tests/core/test_models.py
@@ -9,7 +9,7 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.utils import timezone
 from pytest_django import DjangoAssertNumQueries
 
-from docurba.core.enums import TypeCollectivite
+from docurba.core.enums import CommuneType, TypeCollectivite
 from docurba.core.models import (
     EVENT_CATEGORY_BY_DOC_TYPE,
     Adhesion,
@@ -623,6 +623,72 @@ class TestProcedure:
         )
 
         assert procedure.perimetre.through.objects.count() == 1
+
+    @pytest.mark.django_db
+    def test_computed_name(self) -> None:
+        expected_name = "Procedure name"
+        procedure = ProcedureFactory(name=expected_name)
+        assert procedure.computed_name == expected_name
+
+        expected_name = (
+            "Élaboration 1 PLU Syndicat mixte d'équipement de la commune de Beaucaire"
+        )
+        procedure = ProcedureFactory(
+            name="",
+            numero="1",
+            collectivite_porteuse__for_snapshot=True,
+            doc_type=TypeDocument.PLU,
+        )
+        assert procedure.computed_name == expected_name
+
+        expected_name = (
+            "Élaboration PLU Syndicat mixte d'équipement de la commune de Beaucaire"
+        )
+        procedure = ProcedureFactory(
+            name="",
+            collectivite_porteuse__for_snapshot=True,
+            doc_type=TypeDocument.PLU,
+        )
+        assert procedure.computed_name == expected_name
+
+    @pytest.mark.django_db
+    def test_perimetre_name(self) -> None:
+        collectivite_porteuse = CollectiviteFactory(
+            nom="CC de la Terre d'Argence", type=TypeCollectivite.CC
+        )
+        procedure = ProcedureFactory(
+            with_perimetre=[CommuneFactory(nom="Beaucaire")],
+            collectivite_porteuse=collectivite_porteuse,
+        )
+        assert procedure.perimetre_name == "Beaucaire"
+
+        procedure = ProcedureFactory(
+            with_perimetre=[
+                CommuneFactory(nom="Beaucaire"),
+                CommuneFactory(nom="Argilliers"),
+            ],
+            collectivite_porteuse=collectivite_porteuse,
+        )
+        assert procedure.perimetre_name == "CC de la Terre d'Argence"
+
+        procedure = ProcedureFactory(
+            with_perimetre=[
+                CommuneFactory(nom="Beaucaire"),
+                CommuneFactory(nom="Argilliers", type=CommuneType.COMD),
+            ],
+            collectivite_porteuse=collectivite_porteuse,
+        )
+        assert procedure.perimetre_name == "Beaucaire (COM), Argilliers (COMD)"
+
+        procedure = ProcedureFactory(
+            with_perimetre=[
+                CommuneFactory(nom="Beaucaire"),
+                CommuneFactory(nom="Nîmes"),
+                CommuneFactory(nom="Argilliers", type=CommuneType.COMD),
+            ],
+            collectivite_porteuse=collectivite_porteuse,
+        )
+        assert procedure.perimetre_name == "CC de la Terre d'Argence"
 
 
 class TestProcedureDates:

--- a/django/tests/internal_api/test_views/__snapshots__/test_procedure_views.ambr
+++ b/django/tests/internal_api/test_views/__snapshots__/test_procedure_views.ambr
@@ -1,0 +1,664 @@
+# serializer version: 1
+# name: TestProcedureList.test_collectivites_porteuses[default_value]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '30001',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Aigaliers',
+        'regionCode': '76',
+        'siren': '',
+        'type': 'COM',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-222222222222',
+      'name': "Révision du PLU d'Aigaliers",
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30001',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Aigaliers',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': '1cd65b57-7027-4aa5-8d19-333333333333',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '30002',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Aigremont',
+        'regionCode': '76',
+        'siren': '',
+        'type': 'COM',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-444444444444',
+      'name': "Révision du PLU d'Aigremont",
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30002',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Aigremont',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': '1cd65b57-7027-4aa5-8d19-555555555555',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_collectivites_porteuses[not_found]
+  list([
+  ])
+# ---
+# name: TestProcedureList.test_collectivites_porteuses[one_collectivite_porteuse_code_insee]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '30001',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Aigaliers',
+        'regionCode': '76',
+        'siren': '',
+        'type': 'COM',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-222222222222',
+      'name': "Révision du PLU d'Aigaliers",
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30001',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Aigaliers',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': '1cd65b57-7027-4aa5-8d19-333333333333',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_collectivites_porteuses[one_collectivite_porteuse_siren]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_collectivites_porteuses[several_collectivites_porteuses]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '30001',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Aigaliers',
+        'regionCode': '76',
+        'siren': '',
+        'type': 'COM',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-222222222222',
+      'name': "Révision du PLU d'Aigaliers",
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30001',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Aigaliers',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': '1cd65b57-7027-4aa5-8d19-333333333333',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_communes_perimetre[default_value]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-222222222222',
+      'name': 'Seconde procédure',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30034',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Bellegarde',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-333333333333',
+      'name': 'Troisième procédure',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30117',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Fourques',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_communes_perimetre[not_found]
+  list([
+  ])
+# ---
+# name: TestProcedureList.test_communes_perimetre[one_commune]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_communes_perimetre[several_communes]
+  list([
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-222222222222',
+      'name': 'Seconde procédure',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30034',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Bellegarde',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'parent': None,
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+  ])
+# ---
+# name: TestProcedureList.test_is_principale_filter[default_value]
+  2
+# ---
+# name: TestProcedureList.test_is_principale_filter[is_principale0]
+  1
+# ---
+# name: TestProcedureList.test_is_principale_filter[is_principale1]
+  1
+# ---
+# name: TestProcedureList.test_nominal_principal_procedure_serializer
+  dict({
+    'count': 1,
+    'next': None,
+    'num_pages': 1,
+    'previous': None,
+    'results': list([
+      dict({
+        'collectivite_porteuse': dict({
+          'codeInsee': '',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+          'regionCode': '76',
+          'siren': '253000020',
+          'type': 'SMO',
+        }),
+        'docType': 'PLU',
+        'id': '1cd65b57-7027-4aa5-8d19-5e1baf8d6f09',
+        'name': 'Élaboration du PLU de Nantes',
+        'numero': '1',
+        'parent': None,
+        'perimetre': list([
+          dict({
+            'code': '30032',
+            'departementCode': '30',
+            'intercommunaliteCode': '',
+            'intitule': 'Beaucaire',
+            'regionCode': '76',
+            'type': 'COM',
+          }),
+          dict({
+            'code': '30034',
+            'departementCode': '30',
+            'intercommunaliteCode': '',
+            'intitule': 'Bellegarde',
+            'regionCode': '76',
+            'type': 'COM',
+          }),
+          dict({
+            'code': '30117',
+            'departementCode': '30',
+            'intercommunaliteCode': '',
+            'intitule': 'Fourques',
+            'regionCode': '76',
+            'type': 'COM',
+          }),
+          dict({
+            'code': '30135',
+            'departementCode': '30',
+            'intercommunaliteCode': '',
+            'intitule': 'Jonquières-Saint-Vincent',
+            'regionCode': '76',
+            'type': 'COM',
+          }),
+          dict({
+            'code': '30336',
+            'departementCode': '30',
+            'intercommunaliteCode': '',
+            'intitule': 'Vallabrègues',
+            'regionCode': '76',
+            'type': 'COM',
+          }),
+        ]),
+        'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+        'startedBeforeHuwartLaw': False,
+        'status': 'en cours',
+        'topics': list([
+        ]),
+        'type': 'Élaboration',
+      }),
+    ]),
+  })
+# ---
+# name: TestProcedureList.test_nominal_secondary_procedure_serializer
+  dict({
+    'collectivite_porteuse': dict({
+      'codeInsee': '',
+      'departementCode': '30',
+      'intercommunaliteCode': '',
+      'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+      'regionCode': '76',
+      'siren': '253000020',
+      'type': 'SMO',
+    }),
+    'docType': 'PLU',
+    'id': '1cd65b57-7027-4aa5-8d19-222222222222',
+    'name': 'Révision du PLU de Nantes',
+    'numero': '1',
+    'parent': dict({
+      'collectivite_porteuse': dict({
+        'codeInsee': '',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': "Syndicat mixte d'équipement de la commune de Beaucaire",
+        'regionCode': '76',
+        'siren': '253000020',
+        'type': 'SMO',
+      }),
+      'docType': 'PLU',
+      'id': '1cd65b57-7027-4aa5-8d19-111111111111',
+      'name': 'Élaboration du PLU de Nantes',
+      'numero': '1',
+      'perimetre': list([
+        dict({
+          'code': '30032',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Beaucaire',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+        dict({
+          'code': '30034',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Bellegarde',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+        dict({
+          'code': '30117',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Fourques',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+        dict({
+          'code': '30135',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Jonquières-Saint-Vincent',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+        dict({
+          'code': '30336',
+          'departementCode': '30',
+          'intercommunaliteCode': '',
+          'intitule': 'Vallabrègues',
+          'regionCode': '76',
+          'type': 'COM',
+        }),
+      ]),
+      'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+      'startedBeforeHuwartLaw': False,
+      'status': 'en cours',
+      'topics': list([
+      ]),
+      'type': 'Élaboration',
+    }),
+    'perimetre': list([
+      dict({
+        'code': '30032',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Beaucaire',
+        'regionCode': '76',
+        'type': 'COM',
+      }),
+      dict({
+        'code': '30034',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Bellegarde',
+        'regionCode': '76',
+        'type': 'COM',
+      }),
+      dict({
+        'code': '30117',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Fourques',
+        'regionCode': '76',
+        'type': 'COM',
+      }),
+      dict({
+        'code': '30135',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Jonquières-Saint-Vincent',
+        'regionCode': '76',
+        'type': 'COM',
+      }),
+      dict({
+        'code': '30336',
+        'departementCode': '30',
+        'intercommunaliteCode': '',
+        'intitule': 'Vallabrègues',
+        'regionCode': '76',
+        'type': 'COM',
+      }),
+    ]),
+    'project_id': 'fb48c069-33c6-4ed2-9db3-054e99ea7981',
+    'startedBeforeHuwartLaw': False,
+    'status': 'en cours',
+    'topics': list([
+    ]),
+    'type': 'Élaboration',
+  })
+# ---

--- a/django/tests/internal_api/test_views/test_procedure_views.py
+++ b/django/tests/internal_api/test_views/test_procedure_views.py
@@ -349,6 +349,90 @@ class TestProcedureList:
         assert response.status_code == 200
         assert response.json()["results"][0]["topics"] == [{"name": "zan"}]
 
+    def test_procedure_name__one_commune(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        ProcedureFactory(
+            name="",
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes[:1],
+            id=uuid.UUID("11111111-7027-4aa5-8d19-222222222222"),
+            for_snapshot=True,
+        )
+        ProcedureFactory(name="", id=uuid.UUID("22222222-7027-4aa5-8d19-222222222222"))
+        ProcedureFactory(name="", id=uuid.UUID("33333333-7027-4aa5-8d19-333333333333"))
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}")
+        assert response.status_code == 200
+        assert response.json()["results"][0]["name"] == "Élaboration PLU Beaucaire"
+
+    def test_procedure_name__comd(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        ProcedureFactory(
+            name="",
+            collectivite_porteuse=collectivite,
+            with_perimetre=[
+                communes[0],
+                CommuneFactory(nom="Argilliers", type=CommuneType.COMD),
+            ],
+            id=uuid.UUID("11111111-7027-4aa5-8d19-222222222222"),
+            for_snapshot=True,
+        )
+        ProcedureFactory(name="", id=uuid.UUID("22222222-7027-4aa5-8d19-222222222222"))
+        ProcedureFactory(name="", id=uuid.UUID("33333333-7027-4aa5-8d19-333333333333"))
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}")
+        assert response.status_code == 200
+        assert (
+            response.json()["results"][0]["name"]
+            == "Élaboration PLUiS Beaucaire (COM), Argilliers (COMD)"
+        )
+
+    def test_procedure_name__collectivite_porteuse(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        ProcedureFactory(
+            name="",
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+            id=uuid.UUID("11111111-7027-4aa5-8d19-222222222222"),
+            for_snapshot=True,
+        )
+        ProcedureFactory(name="", id=uuid.UUID("22222222-7027-4aa5-8d19-222222222222"))
+        ProcedureFactory(name="", id=uuid.UUID("33333333-7027-4aa5-8d19-333333333333"))
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}")
+        assert response.status_code == 200
+        assert (
+            response.json()["results"][0]["name"]
+            == "Élaboration PLUi Syndicat mixte d'équipement de la commune de Beaucaire"
+        )
+
     def test_nominal_principal_procedure_serializer(
         self,
         api_client_with_auth: SupabaseApiClient,

--- a/django/tests/internal_api/test_views/test_procedure_views.py
+++ b/django/tests/internal_api/test_views/test_procedure_views.py
@@ -1,0 +1,418 @@
+import random
+import uuid
+from urllib.parse import urlencode
+
+import pytest
+from django.urls import reverse
+from pytest_django import DjangoAssertNumQueries
+from syrupy.assertion import SnapshotAssertion
+
+from docurba.core.enums import CommuneType, TypeCollectivite
+from docurba.core.models import (
+    Collectivite,
+    Commune,
+    ProcedureStatusChoices,
+    Topic,
+    TypeDocument,
+)
+from docurba.users.models import Profile
+from tests.conftest import SupabaseApiClient
+from tests.core.factories import (
+    CollectiviteFactory,
+    CommuneFactory,
+    ProcedureFactory,
+    ProjectFactory,
+)
+from tests.users.factories import ProfileFactory
+
+BASE_QUERIES = (
+    1  # session
+    + 1  # count for pagination
+    + 1  # procedures details
+    + 1  # topics
+    + 1  # perimetre
+)
+
+
+@pytest.mark.django_db
+class TestProcedureList:
+    def _create_collectivite_perimetre_profile(
+        self,
+    ) -> tuple[Collectivite, Commune, Profile]:
+        #     # This test assumes no one has the jurisdiction because
+        #     # collectivite.competence_plan and collectivite.competence_schema
+        #     # are False by default.
+        #     # In this particular case, which should not happen in the reality,
+        #     # the system chooses the collectivite to be the `collectivite porteuse``.
+        #     # Jurisdiction are omitted in this test to avoid `collectivite porteuse` differences.
+        #     # They are tested separately.
+        # TODO: get collectivite from the logged in user depending on the user rights.  # noqa: FIX002
+        collectivite = CollectiviteFactory(
+            for_snapshot=True,
+            with_flat_members=True,
+            with_flat_members__for_snapshot=True,
+        )
+        perimetre_insee_codes = collectivite.flat_members.filter(
+            type=CommuneType.COM
+        ).values_list("code_insee", flat=True)
+        communes = Commune.objects.filter(code_insee__in=perimetre_insee_codes)
+        logged_in_profile = ProfileFactory(
+            with_collectivite=True, with_collectivite__collectivite=collectivite
+        )
+        return collectivite, communes, logged_in_profile
+
+    @property
+    def url(self) -> str:
+        return reverse("internal_api:procedures-list")
+
+    @pytest.mark.parametrize("status", ProcedureStatusChoices)
+    def test_status_filter(
+        self,
+        status: str,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        expected_procedure = ProcedureFactory(
+            status=status,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        excluded_status = random.choice(  # noqa: S311
+            [p_status for p_status in ProcedureStatusChoices if p_status != status]
+        )
+        ProcedureFactory(
+            status=excluded_status,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}?status={status}")
+        assert response.status_code == 200
+        assert response.json()["count"] == 1
+        assert response.json()["results"][0]["status"] == status.value
+        assert response.json()["results"][0]["id"] == str(expected_procedure.id)
+
+    def test_many_statuses_filter(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        expected_procedure_one = ProcedureFactory(
+            status=ProcedureStatusChoices.OPPOSABLE,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        expected_procedure_two = ProcedureFactory(
+            status=ProcedureStatusChoices.EN_COURS,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        not_expected_procedure = ProcedureFactory(
+            status=ProcedureStatusChoices.ABANDON,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(
+                f"{self.url}?status={ProcedureStatusChoices.OPPOSABLE}&status={ProcedureStatusChoices.EN_COURS}"
+            )
+        assert response.status_code == 200
+        assert response.json()["count"] == 2
+        results_procedure_ids = [result["id"] for result in response.json()["results"]]
+        assert sorted(
+            [str(expected_procedure_one.id), str(expected_procedure_two.id)]
+        ) == sorted(results_procedure_ids)
+        assert not_expected_procedure not in results_procedure_ids
+
+    @pytest.mark.parametrize(
+        ("query_params"),
+        [
+            pytest.param(
+                {"is_principale": "true"},
+                id="is_principale",
+            ),
+            pytest.param(
+                {"is_principale": "false"},
+                id="is_principale",
+            ),
+            pytest.param(
+                {},
+                id="default_value",
+            ),
+        ],
+    )
+    def test_is_principale_filter(
+        self,
+        query_params: dict,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+        snapshot: SnapshotAssertion,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        ProcedureFactory(
+            is_principale=True,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        ProcedureFactory(
+            is_principale=False,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+        )
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}?{urlencode(query_params)}")
+        assert response.status_code == 200
+        assert response.json()["count"] == snapshot()
+
+    @pytest.mark.parametrize(
+        ("query_params"),
+        [
+            pytest.param(
+                {"collectivites_porteuses": ["253000020", "30001"]},
+                id="several_collectivites_porteuses",
+            ),
+            pytest.param(
+                {"collectivites_porteuses": ["253000020"]},
+                id="one_collectivite_porteuse_siren",
+            ),
+            pytest.param(
+                {"collectivites_porteuses": ["30001"]},
+                id="one_collectivite_porteuse_code_insee",
+            ),
+            # # Don't raise an error for the moment.
+            pytest.param(
+                {"collectivites_porteuses": ["00000"]},
+                id="not_found",
+            ),
+            pytest.param(
+                {},
+                id="default_value",
+            ),
+        ],
+    )
+    def test_collectivites_porteuses(
+        self,
+        query_params: dict,
+        snapshot: SnapshotAssertion,
+        api_client_with_auth: SupabaseApiClient,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        ProcedureFactory(
+            with_perimetre=[communes[0]],
+            collectivite_porteuse=collectivite,
+            numero="1",
+            for_snapshot=True,
+            status=ProcedureStatusChoices.EN_COURS,
+        )
+        collectivite_with_code_insee = CommuneFactory(
+            departement__code_insee="30",
+            code_insee="30001",
+            type=TypeCollectivite.COM,
+            nom="Aigaliers",
+        )
+        ProcedureFactory(
+            pk=uuid.UUID("1cd65b57-7027-4aa5-8d19-222222222222"),
+            name="Révision du PLU d'Aigaliers",
+            status=ProcedureStatusChoices.EN_COURS,
+            collectivite_porteuse=collectivite_with_code_insee,
+            with_perimetre=[collectivite_with_code_insee],
+            numero="1",
+            project=ProjectFactory(
+                id=uuid.UUID("1cd65b57-7027-4aa5-8d19-333333333333")
+            ),
+            doc_type=TypeDocument.PLU,
+        )
+        aigremont = CommuneFactory(code_insee="30002")
+        ProcedureFactory(
+            pk=uuid.UUID("1cd65b57-7027-4aa5-8d19-444444444444"),
+            name="Révision du PLU d'Aigremont",
+            status=ProcedureStatusChoices.EN_COURS,
+            collectivite_porteuse=aigremont,
+            with_perimetre=[aigremont],
+            numero="1",
+            project=ProjectFactory(
+                id=uuid.UUID("1cd65b57-7027-4aa5-8d19-555555555555")
+            ),
+            doc_type=TypeDocument.PLU,
+        )
+        with api_client_with_auth(logged_in_profile) as api_client:
+            response = api_client.get(
+                f"{self.url}?{urlencode(query_params, doseq=True)}"
+            )
+        assert response.status_code == 200
+        assert response.json()["results"] == snapshot()
+
+    @pytest.mark.parametrize(
+        ("query_params"),
+        [
+            pytest.param(
+                {"communes_perimetre": ["30032", "30034"]},
+                id="several_communes",
+            ),
+            pytest.param(
+                {"communes_perimetre": ["30032"]},
+                id="one_commune",
+            ),
+            # # Don't raise an error for the moment.
+            pytest.param(
+                {"communes_perimetre": ["00000"]},
+                id="not_found",
+            ),
+            pytest.param(
+                {},
+                id="default_value",
+            ),
+        ],
+    )
+    def test_communes_perimetre(
+        self,
+        query_params: dict,
+        snapshot: SnapshotAssertion,
+        api_client_with_auth: SupabaseApiClient,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        procedure = ProcedureFactory(
+            with_perimetre=[communes[0]],
+            collectivite_porteuse=collectivite,
+            numero="1",
+            for_snapshot=True,
+            status=ProcedureStatusChoices.EN_COURS,
+        )
+        ProcedureFactory(
+            pk=uuid.UUID("1cd65b57-7027-4aa5-8d19-222222222222"),
+            name="Seconde procédure",
+            status=ProcedureStatusChoices.EN_COURS,
+            collectivite_porteuse=collectivite,
+            with_perimetre=[communes[1]],
+            numero="1",
+            project=procedure.project,
+            doc_type=TypeDocument.PLU,
+        )
+        ProcedureFactory(
+            pk=uuid.UUID("1cd65b57-7027-4aa5-8d19-333333333333"),
+            name="Troisième procédure",
+            status=ProcedureStatusChoices.EN_COURS,
+            collectivite_porteuse=collectivite,
+            with_perimetre=[communes[2]],
+            numero="1",
+            project=procedure.project,
+            doc_type=TypeDocument.PLU,
+        )
+        with api_client_with_auth(logged_in_profile) as api_client:
+            response = api_client.get(
+                f"{self.url}?{urlencode(query_params, doseq=True)}"
+            )
+        assert response.status_code == 200
+        assert response.json()["results"] == snapshot()
+
+    def test_serializer_with_topics(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        expected_topic = Topic.objects.get(name="zan")
+        ProcedureFactory(
+            collectivite_porteuse=collectivite,
+            with_perimetre=[communes[0]],
+            with_topics=True,
+            with_topics__list=[expected_topic],
+        )
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}")
+        assert response.status_code == 200
+        assert response.json()["results"][0]["topics"] == [{"name": "zan"}]
+
+    def test_nominal_principal_procedure_serializer(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        snapshot: SnapshotAssertion,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        ProcedureFactory(
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+            numero="1",
+            for_snapshot=True,
+            status=ProcedureStatusChoices.EN_COURS,
+        )
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(BASE_QUERIES),
+        ):
+            response = api_client.get(f"{self.url}")
+        assert response.status_code == 200
+        assert response.json() == snapshot()
+
+    def test_nominal_secondary_procedure_serializer(
+        self,
+        api_client_with_auth: SupabaseApiClient,
+        snapshot: SnapshotAssertion,
+        django_assert_num_queries: DjangoAssertNumQueries,
+    ) -> None:
+        collectivite, communes, logged_in_profile = (
+            self._create_collectivite_perimetre_profile()
+        )
+        principal_procedure = ProcedureFactory(
+            pk=uuid.UUID("1cd65b57-7027-4aa5-8d19-111111111111"),
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+            numero="1",
+            for_snapshot=True,
+            status=ProcedureStatusChoices.EN_COURS,
+        )
+        secondary_procedure = ProcedureFactory(
+            pk=uuid.UUID("1cd65b57-7027-4aa5-8d19-222222222222"),
+            parente=principal_procedure,
+            name="Révision du PLU de Nantes",
+            status=ProcedureStatusChoices.EN_COURS,
+            collectivite_porteuse=collectivite,
+            with_perimetre=communes,
+            numero="1",
+            project=principal_procedure.project,
+            doc_type=TypeDocument.PLU,
+        )
+        with (
+            api_client_with_auth(logged_in_profile) as api_client,
+            django_assert_num_queries(
+                BASE_QUERIES
+                + 1  # parente perimetre
+                + 1  # parente topics
+                + 1  # parente departement?
+                + 1  # parente region?
+            ),
+        ):
+            response = api_client.get(f"{self.url}")
+        assert response.status_code == 200
+        # Results are sorted by ID.
+        assert response.json()["results"][1]["id"] == str(secondary_procedure.id)
+        assert response.json()["results"][1] == snapshot()

--- a/django/tests/users/factories.py
+++ b/django/tests/users/factories.py
@@ -23,6 +23,7 @@ class SessionFactory(factory.django.DjangoModelFactory):
 class ProfileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Profile
+        skip_postgeneration_save = True
 
     user = factory.SubFactory(
         SupabaseUserFactory, email=factory.SelfAttribute("..email")
@@ -32,3 +33,13 @@ class ProfileFactory(factory.django.DjangoModelFactory):
     lastname = factory.Faker("last_name", locale="fr_FR")
     poste = factory.fuzzy.FuzzyChoice(PosteType)
     other_poste: factory.List([])
+
+    @factory.post_generation
+    def with_collectivite(self, create: bool, extracted: bool, **extra: dict) -> None:  # noqa: FBT001
+        if not create or not extracted:
+            return
+
+        # avoid circular import
+        from tests.core.factories import CollectiviteFactory  # noqa: PLC0415
+
+        self.collectivite = extra.pop("collectivite", CollectiviteFactory())

--- a/nuxt/components/Procedures/InsertForm.vue
+++ b/nuxt/components/Procedures/InsertForm.vue
@@ -95,10 +95,10 @@
                   :items="proceduresParents"
                 >
                   <template #selection="{item}">
-                    {{ $utils.formatProcedureName(item, item.porteuse) }}
+                    {{ item.name }}
                   </template>
                   <template #item="{item}">
-                    {{ $utils.formatProcedureName(item, item.porteuse) }}
+                    {{ item.name }}
                   </template>
                 </v-select>
               </validation-provider>
@@ -187,7 +187,6 @@
 
 <script>
 import { mdiInformationOutline, mdiOpenInNew } from '@mdi/js'
-import axios from 'axios'
 import { uniqBy } from 'lodash'
 import FormInput from '@/mixins/FormInput.js'
 
@@ -279,7 +278,7 @@ export default {
       return this.proceduresParents?.find(e => e.id === this.procedureParent)
     },
     procedureParentDocType () {
-      return this.proceduresParents?.find(e => e.id === this.procedureParent)?.doc_type
+      return this.proceduresParents?.find(e => e.id === this.procedureParent)?.docType
     },
     isLoaded () {
       return this.loaded && (this.procedureCategory === 'principale' || (this.procedureCategory === 'secondaire' && this.proceduresParents !== null))
@@ -288,7 +287,14 @@ export default {
       return (this.collectivite.type === 'COM' && this.perimetre.length > 1) || (this.collectivite.type !== 'COM' && this.perimetre.length < this.communes.length) ? 'S' : ''
     },
     baseName () {
-      return `${this.typeProcedure} ${this.numberProcedure} de ${(this.procedureParent ? this.procedureParentDocType : this.typeDu) + this.postfixSectoriel} ${this.collectivite.intitule}`.replace(/\s+/g, ' ').trim()
+      let name
+      if (this.procedureParentObj) {
+        const regexp = new RegExp(`${this.procedureParentDocType} (.*)`)
+        name = this.procedureParentObj.name.match(regexp)[0].replace(/\s+/g, ' ').trim()
+      } else {
+        name = `${(this.typeDu) + this.postfixSectoriel} ${this.collectivite.intitule}`
+      }
+      return `${this.typeProcedure} ${this.numberProcedure} de ${name}`.replace(/\s+/g, ' ').trim()
     },
     communes () {
       const coms = this.collectivite.membres || this.collectivite.intercommunalite.membres
@@ -340,78 +346,32 @@ export default {
   },
   methods: {
     async getProcedures () {
-      let query = this.$supabase.from('procedures').select('*, procedures_perimetres(*)').eq('is_principale', true).eq('status', 'opposable')
+      const payload = {
+        is_principale: true,
+        status: ['opposable']
+      }
 
       if (this.collectivite.type !== 'COM') {
-        query = query.eq('collectivite_porteuse_id', this.collectivite.code)
+        payload.collectivites_porteuses = [this.collectivite.code]
       } else {
-        query = query.contains('current_perimetre', `[{ "inseeCode": "${this.collectivite.code}" }]`)
+        payload.communes_perimetre = [this.collectivite.code]
       }
 
-      const { data: procedures, error } = await query
-
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.log('error getProcedures', error)
-      }
-      if (procedures.length === 0) {
-        return []
-      }
-
-      const collectiviteCodes = new Set(procedures.flatMap(p => [
-        p.collectivite_porteuse_id,
-        ...p.procedures_perimetres.map(c => c.collectivite_code)
-      ]))
-
-      // TODO :: Migrate this to Django once `groupements` and `membres` are available in `/api-internes/collectivites/`
-      const { data: collectivites } = await axios({
-        url: '/api/geo/collectivites',
-        params: new URLSearchParams(collectiviteCodes.map(code => ['codes', code]))
-      })
-
-      const enrichedProcedures = procedures.map((p) => {
-        const comd = p.procedures_perimetres.find(c => c.collectivite_type === 'COMD')
-
-        const collectivite = collectivites.find((c) => {
-          if (comd) {
-            return c.code === comd.collectivite_code && c.type === 'COMD'
-          } else if (p.procedures_perimetres.length === 1) {
-            return c.code === p.procedures_perimetres[0].collectivite_code
-          } else { return c.code === p.collectivite_porteuse_id }
-        })
-
-        if (collectivite && comd) {
-          collectivite.intitule += ' COMD'
-        }
-
-        return {
-          porteuse: collectivites.find(c => c.code === p.collectivite_porteuse_id),
-          collectivite,
-          ...p
-        }
-      })
-
-      if (this.collectivite.type !== 'COM') {
-        return enrichedProcedures.filter(e =>
-          e.current_perimetre && e.current_perimetre.length > 1
-        )
-      } else {
-        return enrichedProcedures
-      }
+      return await this.$djangoApi.get('/api-internes/procedures/', payload)
     },
     async createProcedure () {
       this.loadingSave = true
 
       try {
-        let perimetre
+        let detailedPerimetre
         if (this.procedureParent) {
-          perimetre = this.procedureParentObj.procedures_perimetres.map(perim => perim.collectivite_code)
+          detailedPerimetre = this.procedureParentObj.perimetre
         } else {
-          perimetre = this.perimetre
+          detailedPerimetre = await this.$djangoApi.get('/api-internes/communes/', {
+            code: this.perimetre,
+            type: 'COM'
+          })
         }
-        const detailedPerimetre = await this.$djangoApi.get('/api-internes/communes/', {
-          code: perimetre
-        })
         const oldFomattedPerimetre = detailedPerimetre.map(e => ({ name: e.intitule, inseeCode: e.code }))
         const departements = [...new Set(detailedPerimetre.map(e => e.departementCode))]
         let insertedProject = null
@@ -469,6 +429,7 @@ export default {
         await this.$supabase.from('core_proceduretopic').insert(topicsToInsert).select()
 
         const fomattedPerimetre = detailedPerimetre.map(e => ({ collectivite_code: e.code, collectivite_type: e.type, procedure_id: insertedProcedure[0].id, opposable: false, departement: e.departementCode }))
+        console.log('fomattedPerimetre', fomattedPerimetre)
         await this.$supabase.from('procedures_perimetres').insert(fomattedPerimetre)
 
         const sender = {
@@ -480,9 +441,6 @@ export default {
           archived: false,
           dev_test: true
         }
-
-        // console.log('this.proceduresParents?.find(e => e.id === this.procedureParent): ', this.proceduresParents?.find(e => e.id === this.procedureParent))
-        // console.log('sender SHARING: ', sender)
 
         const { error: errorInsertedCollabs } = await this.$supabase.from('projects_sharing').insert(sender)
 

--- a/nuxt/plugins/urbanisator.js
+++ b/nuxt/plugins/urbanisator.js
@@ -61,6 +61,7 @@ export default ({ $collectiviteApi, $supabase, $dayjs }, inject) => {
           return Object.assign({}, collectivite, p)
         })
 
+        // WHAT?!
         procedure.current_perimetre = procedure.procedures_perimetres.filter(c => c.collectivite_type === 'COM').map((p) => {
           const commune = collectivites.find(com => com.code === p.collectivite_code)
 


### PR DESCRIPTION
resolves #2295

TODO :
- [x] Filtre par collectivité porteuse : test
- [x] assert_num_queries
- [ ] Calcul du nom dans Django pour remplacer `$utils.formatProcedureName(item, item.collectivite_porteuse)`.
    - [x] Afficher le nom de la commune (si une seule dans le périmètre). https://github.com/MTES-MCT/Docurba/issues/1143
    - [x] Les titres de procédures de COMD doivent conserver le nom des COMD et non prendre le nom de la commune nouvelle ou l'EPCI https://github.com/MTES-MCT/Docurba/issues/1278 => lors de l'enregistrement (à discuter)
    - [x] À discuter : affichage des procédures principales avec des COMD et une COM (voir ci-dessous).
    - [ ] Discuter de l'affichage COMD / COM.
- [x] Nettoyage
- [x] Remplacer dans Nuxt : Insertform > this.getProcedures()
- [x] Vérifier que les procédures sur une seule commune sont bien trouvées (on n'utilise plus `current_perimetre`).
- [x] Script : vérifier que `current_perimetre` == `procedures_perimetre` est toujours vrai.
- [ ] Calculer les droits de l'utilisateur : quelles sont les procédures qu'il a le droit de voir ? Sur quel périmètre ? comment calculer le périmètre de l'utilisateur ? => autre PR

Pas pour le moment : 
    - [ ] Afficher le statut Précédent ou Opposable https://github.com/MTES-MCT/Docurba/issues/1039 => pas pour le moment

Proposition pour les procédures sur une commune mais avec une ou plusieurs COMD :
Un bon exemple pour tester : http://localhost:3000/ddt/01/collectivites/01185/commune
<img width="1793" height="918" alt="image" src="https://github.com/user-attachments/assets/81cdc3c0-8ba6-4f4e-9c50-3498e3a0ef81" />

# Current perimetre

Il y a de nombreuses différences. En local, j'ai 714 enregistrements dont le périmètre ne concorde pas avec `procedures_perimetre`.
À creuser avec le métier.
La requête est loin d'être optimisée mais elle fonctionne.

```sql
with cta as (
select 
p.current_perimetre as hey, 
array_agg(distinct perimetre->>'inseeCode' order by perimetre->>'inseeCode' asc) as json_perimetre,
array_agg(distinct pp.collectivite_code order by pp.collectivite_code asc) as pp_perimetre
from procedures p
cross join json_array_elements(current_perimetre::json) as perimetre
left join procedures_perimetres pp on pp.procedure_id = p.id
group by p.id
)
select *
from cta
where cta.json_perimetre != cta.pp_perimetre;
```
