### PR TITLE
EventType - Modification du Queryset par défaut

### DIFF
--- a/django/docurba/core/admin.py
+++ b/django/docurba/core/admin.py
@@ -348,7 +348,7 @@ class EventTypeAdmin(admin.ModelAdmin):
     search_fields = ("name", "sudocuh_name", "sudocuh_code")
 
     def get_queryset(self, request) -> models.QuerySet:
-        return self.model.all_objects.get_queryset()
+        return self.model.objects.get_queryset()
 
     def has_delete_permission(self, request, obj=None) -> bool:
         return False

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -941,8 +941,8 @@ class EventType(models.Model):
         verbose_name="mis à jour le", auto_now=True, null=True
     )
 
-    objects = ActiveEventTypeManager()
-    all_objects = EventTypeManager()
+    objects = EventTypeManager()
+    active_objects = ActiveEventTypeManager()
 
     class Meta:
         verbose_name = "type d'évènement"

--- a/django/docurba/internal_api/views.py
+++ b/django/docurba/internal_api/views.py
@@ -85,6 +85,6 @@ class CommuneViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class EventTypeViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = EventType.objects.all()
+    queryset = EventType.active_objects.all()
     serializer_class = EventTypeSerializer
     filterset_class = custom_filters.EventTypeFilter


### PR DESCRIPTION
- le queryset par défaut (objects) n'est plus filtré
- ajout du queryset active_objects avec des éléments filtrés