### PR TITLE
Erreur d'intégrité : collectivité porteuse inexistante

### DIFF
--- a/django/docurba/core/management/commands/list_inconsistencies_procedure_collectivite_porteuse_inexisting.py
+++ b/django/docurba/core/management/commands/list_inconsistencies_procedure_collectivite_porteuse_inexisting.py
@@ -1,0 +1,26 @@
+import csv
+
+from django.core.management.base import BaseCommand
+from django.db.models import Exists, OuterRef
+
+from docurba.core.models import Collectivite, Procedure
+
+
+class Command(BaseCommand):
+    help = """
+        List procedures for which no collectivite porteuse exists
+    """
+
+    def handle(self, *args: list, **options: dict) -> None:  # noqa: ARG002
+        collectivites = Collectivite.objects.filter(
+            code_insee_unique=OuterRef("collectivite_porteuse_id"),
+        )
+        procedures = Procedure.objects.filter(~Exists(collectivites)).order_by(
+            "collectivite_porteuse_id"
+        )
+
+        writer = csv.writer(self.stdout, lineterminator="\n")
+
+        writer.writerow(["procedure.collectivite_porteuse_id", "procedure_id"])
+        for procedure in procedures.iterator():
+            writer.writerow([procedure.collectivite_porteuse_id, procedure.id])

--- a/django/docurba/core/management/commands/list_inconsistencies_procedure_collectivite_porteuse_invalid.py
+++ b/django/docurba/core/management/commands/list_inconsistencies_procedure_collectivite_porteuse_invalid.py
@@ -1,0 +1,63 @@
+import csv
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count, F, Max, OuterRef, Subquery
+
+from docurba.core.enums import CommuneType
+from docurba.core.models import CommuneProcedure, Procedure
+
+
+class Command(BaseCommand):
+    help = """
+        List procedures for which the collectivite porteuse is invalid :
+        - The collectivite porteuse of a procedure should be the commune when the perimeter of the procedure contains only this commune
+    """
+
+    def add_arguments(self, parser: str) -> None:
+        parser.add_argument(
+            "--wet-run",
+            dest="wet_run",
+            action="store_true",
+            help="Update procedures by setting collectivite_porteuse_id to procedures_perimetres.collectivite_code",
+        )
+
+    def handle(self, *args: list, wet_run: bool, **options: dict) -> None:  # noqa: ARG002
+        perimetres = (
+            CommuneProcedure.objects.filter(
+                collectivite_type=CommuneType.COM, procedure_id=OuterRef("id")
+            )
+            .values("procedure_id")
+            .annotate(perimetre_count=Count("collectivite_code"))
+            .filter(perimetre_count=1)
+            .annotate(perimetre_code=Max("collectivite_code"))
+            .values("perimetre_code")
+        )
+
+        procedures = (
+            Procedure.objects.annotate(perimetre_code=Subquery(perimetres))
+            .filter(perimetre_code__isnull=False)
+            .exclude(perimetre_code=F("collectivite_porteuse_id"))
+            .values("id", "collectivite_porteuse_id", "perimetre_code")
+            .order_by("id")
+        )
+
+        writer = csv.writer(self.stdout, lineterminator="\n")
+
+        writer.writerow(
+            [
+                "procedure_id",
+                "procedure.collectivite_porteuse_id",
+                "perimetre.collectivite_code",
+            ]
+        )
+        for procedure in procedures.iterator():
+            writer.writerow(
+                [
+                    procedure["id"],
+                    procedure["collectivite_porteuse_id"],
+                    procedure["perimetre_code"],
+                ]
+            )
+
+        if wet_run:
+            procedures.update(collectivite_porteuse_id=F("perimetre_code"))

--- a/django/docurba/core/models.py
+++ b/django/docurba/core/models.py
@@ -422,6 +422,9 @@ class Procedure(models.Model):
     shareable = models.BooleanField(db_default=False)
     type = models.CharField(blank=True, null=True)  # noqa: DJ001 # TextField in DB.
     numero = models.CharField(blank=True, null=True)  # noqa: DJ001 # TextField in DB.
+    # collectivite_porteuse should be non null and reference an unique non nullable column
+    # As code_insee_unique is nullable and non unique, the integrity is not ensured
+    # see django/docurba/core/management/commands/list_inconsistencies_procedure_collectivite_porteuse_inexisting.py
     collectivite_porteuse = models.ForeignKey(
         "Collectivite",
         models.DO_NOTHING,

--- a/django/tests/core/management/commands/test_list_inconsistencies_procedure_collectivite_porteuse_inexisting.py
+++ b/django/tests/core/management/commands/test_list_inconsistencies_procedure_collectivite_porteuse_inexisting.py
@@ -1,0 +1,26 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from tests.core.factories import ProcedureFactory
+
+
+@pytest.mark.django_db
+class TestLinkEventsWithEventTypes:
+    def test_call_command(self) -> None:
+
+        ProcedureFactory()  # Ok
+        procedure = ProcedureFactory(
+            collectivite_porteuse_id=66554
+        )  # Invalid as 66554 doesn't exists
+
+        out = StringIO()
+        call_command(
+            "list_inconsistencies_procedure_collectivite_porteuse_inexisting",
+            stdout=out,
+        )
+        expected = f"""procedure.collectivite_porteuse_id,procedure_id
+{procedure.collectivite_porteuse_id},{procedure.id}
+"""
+        assert expected == out.getvalue()

--- a/django/tests/core/management/commands/test_list_inconsistencies_procedure_collectivite_porteuse_invalid.py
+++ b/django/tests/core/management/commands/test_list_inconsistencies_procedure_collectivite_porteuse_invalid.py
@@ -1,0 +1,57 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from docurba.core.enums import CommuneType
+from tests.core.factories import CommuneFactory, ProcedureFactory
+
+
+@pytest.mark.django_db
+class TestLinkEventsWithEventTypes:
+    def test_call_command(self) -> None:
+
+        commune = CommuneFactory(code_insee="30032")
+        procedure = ProcedureFactory(
+            id="00000000-0000-0000-1111-000000000000",
+            with_perimetre=[commune],
+        )
+
+        procedure_comd = ProcedureFactory(  # COMD are ignored when computing perimeter
+            id="00000000-0000-0000-2222-000000000000",
+            with_perimetre=[
+                commune,
+                CommuneFactory(code_insee="30034", type=CommuneType.COMD),
+            ],
+        )
+
+        procedure_no_perim = ProcedureFactory()  # excluded because no perimeter
+        procedure_multi_perim = ProcedureFactory(  # excluded because perimeter != 1
+            with_perimetre=[commune, CommuneFactory(code_insee="30033")],
+        )
+
+        out = StringIO()
+        call_command(
+            "list_inconsistencies_procedure_collectivite_porteuse_invalid",
+            "--wet-run",
+            stdout=out,
+        )
+        expected = f"""procedure_id,procedure.collectivite_porteuse_id,perimetre.collectivite_code
+{procedure.id},{procedure.collectivite_porteuse_id},{commune.code_insee_unique}
+{procedure_comd.id},{procedure_comd.collectivite_porteuse_id},{commune.code_insee_unique}
+"""
+        assert expected == out.getvalue()
+
+        procedure.refresh_from_db()
+        assert procedure.collectivite_porteuse_id == commune.code_insee_unique
+
+        procedure_comd.refresh_from_db()
+        assert procedure_comd.collectivite_porteuse_id == commune.code_insee_unique
+
+        previous_id = procedure_no_perim.collectivite_porteuse_id
+        procedure_no_perim.refresh_from_db()
+        assert procedure_no_perim.collectivite_porteuse_id == previous_id
+
+        previous_id = procedure_multi_perim.collectivite_porteuse_id
+        procedure_multi_perim.refresh_from_db()
+        assert procedure_multi_perim.collectivite_porteuse_id == previous_id


### PR DESCRIPTION
Ajout de 2 commandes django :

- list_inconsistencies_procedure_collectivite_porteuse_inexisting : Liste les procédures pour lesquelles une collectivite_porteuse est renseignée mais inexistante en base
- list_inconsistencies_procedure_collectivite_porteuse_invalid : Liste les procédures ayant un périmètre d'une seule commune, pour lesquelles la collectivité porteuse est différente du code commune. L'option --wet-run permet de mettre à jour le champ collectivite_porteuse_id avec ce code commune

Les 2 commandes exportent leurs liste de résultat au format csv dans la sortie standard